### PR TITLE
Feature #9: Skeleton Architecture

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "rise_motion_dev_ws/src/SOEM"]
+[submodule "rise_motion_dev_ws/src/rise_motion/SOEM"]
 	path = rise_motion_dev_ws/src/rise_motion/SOEM
 	url = https://github.com/riserobotics/SOEM

--- a/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
+++ b/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
@@ -7,9 +7,27 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-# uncomment the following section in order to fill in
-# further dependencies manually.
-# find_package(<dependency> REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rise_motion_messages REQUIRED)
+
+include_directories(include)
+
+add_subdirectory(SOEM)
+
+add_executable(
+	rise_motion_main
+	src/rise_motion_main.cpp
+)
+target_link_libraries(
+	rise_motion_main
+	PUBLIC rclcpp::rclcpp
+	soem
+	${rise_motion_messages_TARGETS}
+)
+install(TARGETS
+  rise_motion_main
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rise_motion_dev_ws/src/rise_motion/package.xml
+++ b/rise_motion_dev_ws/src/rise_motion/package.xml
@@ -9,6 +9,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>rise_motion_messages</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/rise_motion_dev_ws/src/rise_motion/src/rise_motion_main.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/rise_motion_main.cpp
@@ -1,0 +1,156 @@
+#include <rclcpp/executors/multi_threaded_executor.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <rise_motion_messages/msg/motor_cmd_msg.hpp>
+#include <rise_motion_messages/msg/state_current_msg.hpp>
+#include <rise_motion_messages/srv/enable_ethercat_srv.hpp>
+#include <rise_motion_messages/srv/get_ethercat_parameters_srv.hpp>
+#include <rise_motion_messages/srv/set_ethercat_parameters_srv.hpp>
+
+class RiseMotionMain : public rclcpp::Node {
+public:
+  RiseMotionMain() : Node("rise_motion_main") {
+    setup_publishers();
+    setup_services();
+    setup_subscribers();
+  }
+
+private:
+  void setup_publishers() {
+    output_motor_cmd_publisher =
+        this->create_publisher<rise_motion_messages::msg::MotorCmdMsg>(
+            "output_motor_cmd", 10);
+    rise_motion_state_changes_publisher =
+        this->create_publisher<rise_motion_messages::msg::StateCurrentMsg>(
+            "rise_motion_state_changes", 10);
+  }
+  void setup_services() {
+    enable_ethercat_srv =
+        this->create_service<rise_motion_messages::srv::EnableEthercatSrv>(
+            "enable_ethercat",
+            [this](const std::shared_ptr<rmw_request_id_t> request_header,
+                   const std::shared_ptr<
+                       rise_motion_messages::srv::EnableEthercatSrv::Request>
+                       request,
+                   const std::shared_ptr<
+                       rise_motion_messages::srv::EnableEthercatSrv::Response>
+                       response) {
+              this->handle_enable_ethercat(request_header, request, response);
+            });
+
+    get_ethercat_parameters_srv = this->create_service<
+        rise_motion_messages::srv::GetEthercatParametersSrv>(
+        "get_ethercat_parameters",
+        [this](
+            const std::shared_ptr<rmw_request_id_t> request_header,
+            const std::shared_ptr<
+                rise_motion_messages::srv::GetEthercatParametersSrv::Request>
+                request,
+            const std::shared_ptr<
+                rise_motion_messages::srv::GetEthercatParametersSrv::Response>
+                response) {
+          this->handle_get_ethercat_parameters(request_header, request,
+                                               response);
+        });
+
+    set_ethercat_parameters_srv = this->create_service<
+        rise_motion_messages::srv::SetEthercatParametersSrv>(
+        "set_ethercat_parameters",
+        [this](
+            const std::shared_ptr<rmw_request_id_t> request_header,
+            const std::shared_ptr<
+                rise_motion_messages::srv::SetEthercatParametersSrv::Request>
+                request,
+            const std::shared_ptr<
+                rise_motion_messages::srv::SetEthercatParametersSrv::Response>
+                response) {
+          this->handle_set_ethercat_parameters(request_header, request,
+                                               response);
+        });
+  }
+
+  void setup_subscribers() {
+    input_motor_cmd_subscriber =
+        this->create_subscription<rise_motion_messages::msg::MotorCmdMsg>(
+            "input_motor_cmd", 10,
+            [this](rise_motion_messages::msg::MotorCmdMsg::SharedPtr msg) {
+              handle_input_motor_cmd(msg);
+            });
+  }
+
+  void handle_enable_ethercat(
+      const std::shared_ptr<rmw_request_id_t> request_header,
+      const std::shared_ptr<
+          rise_motion_messages::srv::EnableEthercatSrv::Request>
+          request,
+      const std::shared_ptr<
+          rise_motion_messages::srv::EnableEthercatSrv::Response>
+          response) {
+    (void)request_header;
+    (void)request;
+    (void)response;
+    RCLCPP_WARN(get_logger(), "handle_enable_ethercat not implemented");
+  }
+
+  void handle_set_ethercat_parameters(
+      const std::shared_ptr<rmw_request_id_t> request_header,
+      const std::shared_ptr<
+          rise_motion_messages::srv::SetEthercatParametersSrv::Request>
+          request,
+      const std::shared_ptr<
+          rise_motion_messages::srv::SetEthercatParametersSrv::Response>
+          response) {
+    (void)request_header;
+    (void)request;
+    (void)response;
+    RCLCPP_WARN(get_logger(), "handle_set_ethercat_parameters not implemented");
+  }
+
+  void handle_get_ethercat_parameters(
+      const std::shared_ptr<rmw_request_id_t> request_header,
+      const std::shared_ptr<
+          rise_motion_messages::srv::GetEthercatParametersSrv::Request>
+          request,
+      const std::shared_ptr<
+          rise_motion_messages::srv::GetEthercatParametersSrv::Response>
+          response) {
+    (void)request_header;
+    (void)request;
+    (void)response;
+    RCLCPP_WARN(get_logger(), "handle_get_ethercat_parameters not implemented");
+  }
+
+  void handle_input_motor_cmd(
+      const rise_motion_messages::msg::MotorCmdMsg::SharedPtr msg) {
+    (void)msg;
+    RCLCPP_WARN(get_logger(), "handle_input_motor_cmd not implemented");
+  }
+
+  rclcpp::Publisher<rise_motion_messages::msg::StateCurrentMsg>::SharedPtr
+      rise_motion_state_changes_publisher;
+  rclcpp::Publisher<rise_motion_messages::msg::MotorCmdMsg>::SharedPtr
+      output_motor_cmd_publisher;
+
+  rclcpp::Service<rise_motion_messages::srv::EnableEthercatSrv>::SharedPtr
+      enable_ethercat_srv;
+  rclcpp::Service<rise_motion_messages::srv::SetEthercatParametersSrv>::
+      SharedPtr set_ethercat_parameters_srv;
+  rclcpp::Service<rise_motion_messages::srv::GetEthercatParametersSrv>::
+      SharedPtr get_ethercat_parameters_srv;
+
+  rclcpp::Subscription<rise_motion_messages::msg::MotorCmdMsg>::SharedPtr
+      input_motor_cmd_subscriber;
+
+};
+
+int main(int argc, char *argv[]) {
+  rclcpp::init(argc, argv);
+
+  rclcpp::Node::SharedPtr node = std::make_shared<RiseMotionMain>();
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(node);
+  executor.spin();
+  
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rise_motion_dev_ws/src/rise_motion_messages/CMakeLists.txt
+++ b/rise_motion_dev_ws/src/rise_motion_messages/CMakeLists.txt
@@ -12,7 +12,10 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/StateCurrentMsg.msg"
   "msg/StateNoticeMsg.msg"
+  "msg/MotorCmdMsg.msg"
   "srv/EnableEthercatSrv.srv"
+  "srv/GetEthercatParametersSrv.srv"
+  "srv/SetEthercatParametersSrv.srv"
  )
 
 if(BUILD_TESTING)

--- a/rise_motion_dev_ws/src/rise_motion_messages/msg/MotorCmdMsg.msg
+++ b/rise_motion_dev_ws/src/rise_motion_messages/msg/MotorCmdMsg.msg
@@ -1,0 +1,1 @@
+int8 motor_cmd

--- a/rise_motion_dev_ws/src/rise_motion_messages/srv/GetEthercatParametersSrv.srv
+++ b/rise_motion_dev_ws/src/rise_motion_messages/srv/GetEthercatParametersSrv.srv
@@ -1,0 +1,3 @@
+int8 request
+---
+int8 response

--- a/rise_motion_dev_ws/src/rise_motion_messages/srv/SetEthercatParametersSrv.srv
+++ b/rise_motion_dev_ws/src/rise_motion_messages/srv/SetEthercatParametersSrv.srv
@@ -1,0 +1,3 @@
+int8 request
+---
+int8 response


### PR DESCRIPTION
This commit set adds the skeleton of the main node (#9). It is supposed to be the base for further development.

In the classes initializer (RiseMotionMain), publisher, subscribers, and services get setup. The main node has private members with handles to these ROS objects as well as functions to handle communication on these channels. They are not implemented yet. The messages on the SetEthercatParameters/GetEthercatParameters are merely placeholders.

The class also has a 1kHz timer which should trigger the publishing of the current motor values.

The SOEM library also gets built but is not yet used anywhere in the code.
