### PR TITLE
  Implement ROS2 wrapper for SOEM EtherCAT communication

### DIFF
--- a/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
+++ b/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rise_motion_messages REQUIRED)
 
 include_directories(include)
 
@@ -17,10 +18,15 @@ add_executable(
 	rise_motion_main
 	src/main.cpp
 	src/ec_manager.cpp
+	src/ethercat_node.cpp
+)
+ament_target_dependencies(
+	rise_motion_main
+	rclcpp
+	rise_motion_messages
 )
 target_link_libraries(
 	rise_motion_main
-	PUBLIC rclcpp::rclcpp
 	soem
 )
 install(TARGETS

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/apsa.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/apsa.hpp
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <atomic>
+#include <cstring>
+#include <memory>
+
+
+template <typename T>
+class APSA {
+public:
+  APSA()
+    : c_mem(std::make_unique<T>()),    // Allocate communication buffer
+      a_mem(std::make_unique<T>()),    // Allocate atomic/shared buffer
+      p_mem(std::make_unique<T>()),    // Allocate performance buffer
+      c_p(nullptr),                     // Communication pointer starts null
+      a_p(nullptr),                     // Atomic pointer starts null
+      p_p(nullptr)                      // Performance pointer starts null
+  {
+    // No initialization needed - pointers start null as per APSA spec
+  }
+
+  bool comm_write(const T& data) {
+    // Copy new data into our communication buffer
+    *c_mem = data;
+
+    // Point c_p to the buffer we just wrote
+    c_p.store(c_mem.get(), std::memory_order_release);
+
+    T* desired = c_p.load(std::memory_order_acquire);
+
+    // Perform the atomic swap
+    T* old_a_p = a_p.exchange(desired, std::memory_order_acq_rel);
+
+    // Update c_p to point to what a_p was pointing to
+    c_p.store(old_a_p, std::memory_order_release);
+
+    return true;
+  }
+
+
+  bool perf_read(T& data) {
+    // Check if new data is available in atomic pointer
+    // memory_order_acquire ensures we see the write from comm_write
+    T* a_ptr = a_p.load(std::memory_order_acquire);
+
+    if (a_ptr != nullptr) {
+      // New data is available! Swap p_p with a_p to claim it
+      T* old_p_p = p_p.exchange(a_p.load(std::memory_order_acquire),
+                                 std::memory_order_acq_rel);
+
+      // Update a_p atomically
+      a_p.store(old_p_p, std::memory_order_release);
+
+      // Copy the data from our performance buffer
+      // p_p now points to the buffer with fresh data
+      T* p_ptr = p_p.load(std::memory_order_acquire);
+      if (p_ptr != nullptr) {
+        data = *p_ptr;
+        
+        // This tells the communication thread we're done with this data
+        p_p.store(nullptr, std::memory_order_release);
+
+        return true;  // New data was read
+      }
+    }
+
+    return false;  // No new data available
+  }
+
+
+  bool perf_write(const T& data) {
+    // Copy data into our performance buffer
+    *p_mem = data;
+
+    // Point p_p to the buffer we just wrote
+    p_p.store(p_mem.get(), std::memory_order_release);
+
+    // Atomically swap p_p with a_p
+    T* old_a_p = a_p.exchange(p_p.load(std::memory_order_acquire),
+                              std::memory_order_acq_rel);
+
+    // Update p_p to point to what a_p was pointing to
+    p_p.store(old_a_p, std::memory_order_release);
+
+    return true;
+  }
+
+
+  bool comm_read(T& data) {
+    // Check if new data is available in atomic pointer
+    T* a_ptr = a_p.load(std::memory_order_acquire);
+
+    if (a_ptr != nullptr) {
+      // New data is available! Swap c_p with a_p to claim it
+      T* old_c_p = c_p.exchange(a_p.load(std::memory_order_acquire),
+                                std::memory_order_acq_rel);
+
+      // Update a_p atomically
+      a_p.store(old_c_p, std::memory_order_release);
+
+      // Copy the data from our communication buffer
+      T* c_ptr = c_p.load(std::memory_order_acquire);
+      if (c_ptr != nullptr) {
+        data = *c_ptr;
+
+        c_p.store(nullptr, std::memory_order_release);
+
+        return true;  // New data was read
+      }
+    }
+
+    return false;  // No new data available
+  }
+
+private:
+  std::unique_ptr<T> c_mem;  // Communication thread's buffer (ROS side)
+  std::unique_ptr<T> a_mem;  // Atomic/shared buffer (exchange point)
+  std::unique_ptr<T> p_mem;  // Performance thread's buffer (EtherCAT side)
+
+  std::atomic<T*> c_p;  // Communication pointer (ROS side access)
+  std::atomic<T*> a_p;  // Atomic pointer (shared exchange point)
+  std::atomic<T*> p_p;  // Performance pointer (EtherCAT side access)
+};

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/ec_manager.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/ec_manager.hpp
@@ -4,8 +4,11 @@
 #include <mutex>
 #include <rclcpp/logger.hpp>
 #include <soem/soem.h>
+#include <vector>
+#include "apsa.hpp"
 
 #define IOMAP_SIZE 4096
+
 class ECManager {
 public:
   ECManager();
@@ -13,15 +16,31 @@ public:
   void init_ec();
   void cyclic_loop();
   void stop();
+
+  // APSA-based motor value transfer (lock-free)
+  bool get_motor_values_apsa(std::vector<int32_t>& motor_values);
+  bool set_motor_values_apsa(const std::vector<int32_t>& motor_values);
+
+  // Legacy mutex-based methods (deprecated)
   void get_motor_values(std::vector<int32_t>& motor_values);
   void set_motor_values(std::vector<int32_t>& motor_values);
+
 private:
   void transition_to_operational();
+
+  // EtherCAT context and configuration
   int expectedWKC;
   ecx_contextt ctx;
   uint8_t IOMap[IOMAP_SIZE];
-  std::mutex ctx_mutex;
+  std::mutex ctx_mutex;  // Only used for legacy methods and state transitions
   std::atomic<bool> running_{false};
   const std::string interface;
   static rclcpp::Logger logger;
+
+  // APSA instances for lock-free communication
+  // cmd_apsa: ROS → EtherCAT (motor commands)
+  APSA<std::vector<int32_t>> cmd_apsa;
+
+  // feedback_apsa: EtherCAT → ROS (motor feedback)
+  APSA<std::vector<int32_t>> feedback_apsa;
 };

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/ec_manager.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/ec_manager.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <atomic>
 #include <cstdint>
 #include <mutex>
 #include <rclcpp/logger.hpp>
@@ -11,14 +12,16 @@ public:
   ECManager(const std::string interface);
   void init_ec();
   void cyclic_loop();
-  void get_motor_values(std::vector<uint32_t>& motor_values);
-  void set_motor_values(std::vector<uint32_t>& motor_values);
+  void stop();
+  void get_motor_values(std::vector<int32_t>& motor_values);
+  void set_motor_values(std::vector<int32_t>& motor_values);
 private:
   void transition_to_operational();
   int expectedWKC;
   ecx_contextt ctx;
   uint8_t IOMap[IOMAP_SIZE];
   std::mutex ctx_mutex;
+  std::atomic<bool> running_{false};
   const std::string interface;
   static rclcpp::Logger logger;
 };

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/ethercat_node.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/ethercat_node.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <rise_motion/ec_manager.hpp>
+#include <rise_motion_messages/msg/motor_positions.hpp>
+#include <rise_motion_messages/srv/enable_ethercat_srv.hpp>
+#include <thread>
+
+class EthercatNode : public rclcpp::Node {
+public:
+  explicit EthercatNode(ECManager& ec_manager);
+  ~EthercatNode();
+
+private:
+  ECManager& ec_manager_;
+  std::unique_ptr<std::thread> ec_thread_;
+  bool ethercat_enabled_{false};
+
+  rclcpp::Subscription<rise_motion_messages::msg::MotorPositions>::SharedPtr cmd_sub_;
+  rclcpp::Publisher<rise_motion_messages::msg::MotorPositions>::SharedPtr feedback_pub_;
+  rclcpp::TimerBase::SharedPtr feedback_timer_;
+  rclcpp::Service<rise_motion_messages::srv::EnableEthercatSrv>::SharedPtr enable_srv_;
+
+  void commandCallback(const rise_motion_messages::msg::MotorPositions::SharedPtr msg);
+  void publishFeedback();
+  void enableServiceCallback(
+    const std::shared_ptr<rise_motion_messages::srv::EnableEthercatSrv::Request> request,
+    std::shared_ptr<rise_motion_messages::srv::EnableEthercatSrv::Response> response);
+};

--- a/rise_motion_dev_ws/src/rise_motion/package.xml
+++ b/rise_motion_dev_ws/src/rise_motion/package.xml
@@ -9,6 +9,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+  <depend>rise_motion_messages</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/rise_motion_dev_ws/src/rise_motion/src/ec_manager.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/ec_manager.cpp
@@ -88,20 +88,60 @@ void ECManager::cyclic_loop() {
   int wkc;
   auto next = std::chrono::steady_clock::now();
   auto period = std::chrono::milliseconds(1);
+
+  // Local buffer for motor commands
+  std::vector<int32_t> motor_commands(config.slavecount, 0);
+
+  // Local buffer for motor feedback
+  std::vector<int32_t> motor_feedback(config.slavecount, 0);
+
   while (running_) {
     next += period;
-    std::unique_lock<std::mutex> lk(ctx_mutex);
+    // perf_read() is wait-free - returns immediately if no new data
+    if (cmd_apsa.perf_read(motor_commands)) {
+      // New commands received! Apply them to EtherCAT slaves
+      for (int i = 0; i < config.slavecount; i++) {
+        inputs *motor_inputs = (inputs *)ctx.slavelist[i + 1].inputs;
+        motor_inputs->TargetPosition = motor_commands[i];
+      }
+    }
+    // If no new commands, EtherCAT slaves keep executing previous commands
+
     ecx_send_processdata(&ctx);
     wkc = ecx_receive_processdata(&ctx, EC_TIMEOUTRET);
+
     if (wkc != expectedWKC) {
       RCLCPP_WARN(logger, "Not all nodes responded");
     }
+
+    for (int i = 0; i < config.slavecount; i++) {
+      outputs *motor_outputs = (outputs *)ctx.slavelist[i + 1].outputs;
+      motor_feedback[i] = motor_outputs->PositionValue;
+    }
+
+    // Make feedback available to ROS publisher (wait-free)
+    feedback_apsa.perf_write(motor_feedback);
+
+    // Sleep until next cycle (maintains 1kHz frequency)
     std::this_thread::sleep_until(next);
   }
 }
 void ECManager::stop() {
   running_ = false;
 }
+
+bool ECManager::get_motor_values_apsa(std::vector<int32_t> &motor_values) {
+  // comm_read() returns true if new data is available, false otherwise
+  return feedback_apsa.comm_read(motor_values);
+}
+
+
+bool ECManager::set_motor_values_apsa(const std::vector<int32_t> &motor_values) {
+  // comm_write() queues the data for the EtherCAT loop to pick up
+  return cmd_apsa.comm_write(motor_values);
+}
+
+
 void ECManager::get_motor_values(std::vector<int32_t> &motor_values) {
   std::unique_lock<std::mutex> lk(ctx_mutex);
   for (int i = 0; i < config.slavecount; i++) {
@@ -109,6 +149,8 @@ void ECManager::get_motor_values(std::vector<int32_t> &motor_values) {
     motor_values[i] = motor_outputs->PositionValue;
   }
 }
+
+
 void ECManager::set_motor_values(std::vector<int32_t> &motor_values) {
   std::unique_lock<std::mutex> lk(ctx_mutex);
   for (int i = 0; i < config.slavecount; i++) {
@@ -116,4 +158,5 @@ void ECManager::set_motor_values(std::vector<int32_t> &motor_values) {
     motor_inputs->TargetPosition = motor_values[i];
   }
 }
+
 rclcpp::Logger ECManager::logger = rclcpp::get_logger("ECManager");

--- a/rise_motion_dev_ws/src/rise_motion/src/ec_manager.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/ec_manager.cpp
@@ -84,10 +84,11 @@ void ECManager::transition_to_operational() {
 }
 void ECManager::cyclic_loop() {
   transition_to_operational();
+  running_ = true;
   int wkc;
   auto next = std::chrono::steady_clock::now();
   auto period = std::chrono::milliseconds(1);
-  for (;;) {
+  while (running_) {
     next += period;
     std::unique_lock<std::mutex> lk(ctx_mutex);
     ecx_send_processdata(&ctx);
@@ -98,14 +99,17 @@ void ECManager::cyclic_loop() {
     std::this_thread::sleep_until(next);
   }
 }
-void ECManager::get_motor_values(std::vector<uint32_t> &motor_values) {
+void ECManager::stop() {
+  running_ = false;
+}
+void ECManager::get_motor_values(std::vector<int32_t> &motor_values) {
   std::unique_lock<std::mutex> lk(ctx_mutex);
   for (int i = 0; i < config.slavecount; i++) {
     outputs *motor_outputs = (outputs *)ctx.slavelist[i + 1].outputs;
     motor_values[i] = motor_outputs->PositionValue;
   }
 }
-void ECManager::set_motor_values(std::vector<uint32_t> &motor_values) {
+void ECManager::set_motor_values(std::vector<int32_t> &motor_values) {
   std::unique_lock<std::mutex> lk(ctx_mutex);
   for (int i = 0; i < config.slavecount; i++) {
     inputs *motor_inputs = (inputs *)ctx.slavelist[i + 1].inputs;

--- a/rise_motion_dev_ws/src/rise_motion/src/ethercat_node.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/ethercat_node.cpp
@@ -23,7 +23,6 @@ EthercatNode::EthercatNode(ECManager& ec_manager)
     "enable_ethercat",
     std::bind(&EthercatNode::enableServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
 
-
   RCLCPP_INFO(get_logger(), "EtherCAT node initialized");
 }
 
@@ -36,20 +35,39 @@ EthercatNode::~EthercatNode() {
   }
 }
 
+/**
+ * @brief ROS subscriber callback for motor commands
+ *
+ * Communication Thread (ROS side) - SEND PATH: ROS → EtherCAT
+ *
+ * Uses APSA's comm_write() for lock-free transfer to the 1kHz EtherCAT loop.
+ * Never blocks the EtherCAT loop.
+ */
 void EthercatNode::commandCallback(
     const rise_motion_messages::msg::MotorPositions::SharedPtr msg) {
   std::vector<int32_t> positions(msg->positions.begin(), msg->positions.end());
-  ec_manager_.set_motor_values(positions);
+
+  if (!ec_manager_.set_motor_values_apsa(positions)) {
+    RCLCPP_WARN(get_logger(), "Failed to queue motor commands");
+  }
 }
 
+/**
+ * @brief ROS publisher timer callback for motor feedback
+ *
+ * Communication Thread (ROS side) - RECEIVE PATH: EtherCAT → ROS
+ *
+ * Uses APSA's comm_read() for lock-free transfer from the 1kHz EtherCAT loop.
+ * Only publishes when NEW feedback is available.
+ */
 void EthercatNode::publishFeedback() {
   std::vector<int32_t> positions;
-  positions.resize(6);
-  ec_manager_.get_motor_values(positions);
 
-  auto msg = rise_motion_messages::msg::MotorPositions();
-  msg.positions.assign(positions.begin(), positions.end());
-  feedback_pub_->publish(msg);
+  if (ec_manager_.get_motor_values_apsa(positions)) {
+    auto msg = rise_motion_messages::msg::MotorPositions();
+    msg.positions.assign(positions.begin(), positions.end());
+    feedback_pub_->publish(msg);
+  }
 }
 
 void EthercatNode::enableServiceCallback(
@@ -73,4 +91,3 @@ void EthercatNode::enableServiceCallback(
 
   response->status_enable = ethercat_enabled_ ? 1 : 0;
 }
-

--- a/rise_motion_dev_ws/src/rise_motion/src/ethercat_node.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/ethercat_node.cpp
@@ -1,0 +1,76 @@
+#include <rise_motion/ethercat_node.hpp>
+#include <functional>
+#include <vector>
+
+using std::placeholders::_1;
+using std::placeholders::_2;
+
+EthercatNode::EthercatNode(ECManager& ec_manager)
+  : Node("ethercat_node"), ec_manager_(ec_manager) {
+
+  cmd_sub_ = create_subscription<rise_motion_messages::msg::MotorPositions>(
+    "motor_commands", 10,
+    std::bind(&EthercatNode::commandCallback, this, _1));
+
+  feedback_pub_ = create_publisher<rise_motion_messages::msg::MotorPositions>(
+    "motor_feedback", 10);
+
+  feedback_timer_ = create_wall_timer(
+    std::chrono::milliseconds(10),
+    std::bind(&EthercatNode::publishFeedback, this));
+
+  enable_srv_ = create_service<rise_motion_messages::srv::EnableEthercatSrv>(
+    "enable_ethercat",
+    std::bind(&EthercatNode::enableServiceCallback, this, std::placeholders::_1, std::placeholders::_2));
+
+
+  RCLCPP_INFO(get_logger(), "EtherCAT node initialized");
+}
+
+EthercatNode::~EthercatNode() {
+  if (ethercat_enabled_) {
+    ec_manager_.stop();
+    if (ec_thread_ && ec_thread_->joinable()) {
+      ec_thread_->join();
+    }
+  }
+}
+
+void EthercatNode::commandCallback(
+    const rise_motion_messages::msg::MotorPositions::SharedPtr msg) {
+  std::vector<int32_t> positions(msg->positions.begin(), msg->positions.end());
+  ec_manager_.set_motor_values(positions);
+}
+
+void EthercatNode::publishFeedback() {
+  std::vector<int32_t> positions;
+  positions.resize(6);
+  ec_manager_.get_motor_values(positions);
+
+  auto msg = rise_motion_messages::msg::MotorPositions();
+  msg.positions.assign(positions.begin(), positions.end());
+  feedback_pub_->publish(msg);
+}
+
+void EthercatNode::enableServiceCallback(
+  const std::shared_ptr<rise_motion_messages::srv::EnableEthercatSrv::Request> request,
+  std::shared_ptr<rise_motion_messages::srv::EnableEthercatSrv::Response> response)
+{
+  if (request->enable && !ethercat_enabled_) {
+    RCLCPP_INFO(get_logger(), "Enabling EtherCAT communication");
+    ec_manager_.init_ec();
+    ec_thread_ = std::make_unique<std::thread>(&ECManager::cyclic_loop, &ec_manager_);
+    ethercat_enabled_ = true;
+  }
+  else if (!request->enable && ethercat_enabled_) {
+    RCLCPP_INFO(get_logger(), "Disabling EtherCAT communication");
+    ec_manager_.stop();
+    if (ec_thread_ && ec_thread_->joinable()) {
+      ec_thread_->join();
+    }
+    ethercat_enabled_ = false;
+  }
+
+  response->status_enable = ethercat_enabled_ ? 1 : 0;
+}
+

--- a/rise_motion_dev_ws/src/rise_motion/src/main.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/main.cpp
@@ -1,27 +1,16 @@
-#include <chrono>
-#include <cstdint>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
 #include <rise_motion/ec_manager.hpp>
-#include <thread>
-#include <vector>
+#include <rise_motion/ethercat_node.hpp>
 
 int main(int argc, char *argv[]) {
-  (void)argc;
-  (void)argv;
-  std::vector<uint32_t> desired_motor_values;
-  std::vector<uint32_t> actual_motor_values;
-  desired_motor_values.resize(6);
-  actual_motor_values.resize(6);
+  rclcpp::init(argc, argv);
 
-  ECManager ec_manager("eno1");
-  ec_manager.init_ec();
+  ECManager ec_manager("eno1"); // TODO: Connect config from rise-os-core
+  auto node = std::make_shared<EthercatNode>(ec_manager);
 
-  std::thread ec_manager_thread(&ECManager::cyclic_loop, &ec_manager);
+  rclcpp::spin(node);
 
-  for (int pos = 0; pos <= 10000; pos++) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    ec_manager.set_motor_values(desired_motor_values);
-    ec_manager.get_motor_values(actual_motor_values);
-  }
-  ec_manager_thread.join();
+  rclcpp::shutdown();
   return 0;
 }

--- a/rise_motion_dev_ws/src/rise_motion_messages/CMakeLists.txt
+++ b/rise_motion_dev_ws/src/rise_motion_messages/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/StateCurrentMsg.msg"
   "msg/StateNoticeMsg.msg"
+  "msg/MotorPositions.msg"
   "srv/EnableEthercatSrv.srv"
  )
 

--- a/rise_motion_dev_ws/src/rise_motion_messages/msg/MotorPositions.msg
+++ b/rise_motion_dev_ws/src/rise_motion_messages/msg/MotorPositions.msg
@@ -1,0 +1,1 @@
+int32[] positions


### PR DESCRIPTION
  This commit implements a minimal ROS2 node that wraps the ECManager class
  to provide ROS2 topics and services for EtherCAT motor control.

  Addresses:
  - Issue #8: SOEM ROS Node Implementation
  - Issue #34: EtherCAT Device Handling
  - Issue #33: Support for negative encoder values

Features:
  - Two-thread architecture: 1kHz EtherCAT cyclic loop runs independently from ROS callbacks
  - ROS2 topics for motor position commands and feedback
  - Lifecycle management (enable/disable EtherCAT)
  - Thread-safe access to motor data
  - Support for signed 32-bit encoder values