### PR TITLE
rise_motion: CMakeLists.txt: Add header files dir + SOEM.

### DIFF
--- a/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
+++ b/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
@@ -5,20 +5,15 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# find dependencies
 find_package(ament_cmake REQUIRED)
-# uncomment the following section in order to fill in
-# further dependencies manually.
-# find_package(<dependency> REQUIRED)
+
+include_directories(include)
+
+add_subdirectory(SOEM)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
   set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()


### PR DESCRIPTION
Includes SOEM in Project and configures include-directories.