### PR TITLE
rise_motion: Add CiA402 State Machine.

### DIFF
--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/cia402.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/cia402.hpp
@@ -1,0 +1,114 @@
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <osal_defs.h>
+
+OSAL_PACKED_BEGIN
+typedef struct OSAL_PACKED {
+  uint16_t Statusword;
+  int8_t OpModeDisplay;
+  int32_t PositionValue;
+  int32_t VelocityValue;
+  int16_t TorqueValue;
+  uint16_t AnalogInput1;
+  uint16_t AnalogInput2;
+  uint16_t AnalogInput3;
+  uint16_t AnalogInput4;
+  uint32_t TuningStatus;
+  uint32_t DigitalInputs;
+  uint32_t UserMISO;
+  uint32_t Timestamp;
+  int32_t PositionDemandInternalValue;
+  int32_t VelocityDemandValue;
+  int16_t TorqueDemand;
+} CiA402_Inputs;
+OSAL_PACKED_END
+
+OSAL_PACKED_BEGIN
+typedef struct OSAL_PACKED {
+  uint16_t Controlword;
+  int8_t OpMode;
+  int16_t TargetTorque;
+  int32_t TargetPosition;
+  int32_t TargetVelocity;
+  int16_t TorqueOffset;
+  int32_t TuningCommand;
+  int32_t PhysicalOutputs;
+  int32_t BitMask;
+  int32_t UserMOSI;
+  int32_t VelocityOffset;
+} CiA402_Outputs;
+OSAL_PACKED_END
+
+class CiA402Motor {
+public:
+  enum class State {
+    NOT_READY_TO_SWITCH_ON,
+    SWITCH_ON_DISABLED,
+    READY_TO_SWITCH_ON,
+    SWITCHED_ON,
+    OPERATION_ENABLED,
+    QUICK_STOP_ACTIVE,
+    FAULT_REACTION_ACTIVE,
+    FAULT,
+  };
+
+  enum class Operation {
+    SHUTDOWN,
+    SWITCH_ON,
+    DISABLE_VOLTAGE,
+    QUICK_STOP,
+    DISABLE_OPERATION,
+    ENABLE_OPERATION,
+    FAULT_RESET
+  };
+
+  CiA402Motor(CiA402_Inputs *inputs, CiA402_Outputs *outputs);
+
+  std::optional<State> get_state() const;
+  std::string state_as_string() const;
+  bool is_state(State s) const;
+  bool is_operation_enabled() const;
+  bool is_fault() const;
+  
+  void to_operation_enabled();
+  void reset_fault();
+  void set_control_word(Operation op);
+private:
+  struct StatePattern {
+    uint16_t mask;
+    uint16_t value;
+    State state;
+  };
+
+  static constexpr StatePattern state_patterns[] = {
+      // mask     value      state
+      {0b1001111, 0b0000000, State::NOT_READY_TO_SWITCH_ON},
+      {0b1001111, 0b1000000, State::SWITCH_ON_DISABLED},
+      {0b1101111, 0b0100001, State::READY_TO_SWITCH_ON},
+      {0b1101111, 0b0100011, State::SWITCHED_ON},
+      {0b1101111, 0b0100111, State::OPERATION_ENABLED},
+      {0b1101111, 0b0000111, State::QUICK_STOP_ACTIVE},
+      {0b1001111, 0b0001111, State::FAULT_REACTION_ACTIVE},
+      {0b1001111, 0b0001000, State::FAULT}};
+
+  struct ControlPattern {
+    uint16_t mask;
+    uint16_t value;
+    Operation op;
+  };
+
+  static constexpr ControlPattern control_patterns[] = {
+      // mask      value       operation
+      {0b10000111, 0b00000110, Operation::SHUTDOWN},
+      {0b10001111, 0b00000111, Operation::SWITCH_ON},
+      {0b10000010, 0b00000000, Operation::DISABLE_VOLTAGE},
+      {0b10000110, 0b00000010, Operation::QUICK_STOP},
+      {0b10001111, 0b00000111, Operation::DISABLE_OPERATION},
+      {0b10001111, 0b00001111, Operation::ENABLE_OPERATION},
+      {0b10000000, 0b10000000, Operation::FAULT_RESET}};
+
+  CiA402_Inputs *inputs;
+  CiA402_Outputs *outputs;
+};

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/cia402.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/cia402.hpp
@@ -83,6 +83,19 @@ public:
 
   CiA402Motor(CiA402_Inputs *inputs, CiA402_Outputs *outputs);
 
+  /**
+   * @brief Gets the motor's current state based on its status word.
+   *
+   * Compares the status word against predefined patterns. Returns the matching
+   * state, or `std::nullopt` if no match is found.
+   *
+   * @return The motor's state if a match is found; otherwise, `std::nullopt`.
+   *
+   * @warning Returning `std::nullopt` indicates an unrecognized status word.
+   *          Callers must handle this case to avoid undefined behavior.
+   *
+   * @see CiA402Motor::State, state_patterns
+   */
   std::optional<State> get_state() const;
   std::string state_as_string() const;
   bool is_state(State s) const;

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/cia402.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/cia402.hpp
@@ -64,6 +64,7 @@ public:
     FAULT_RESET
   };
 
+  // https://doc.synapticon.com/circulo/sw5.4/objects_html/6xxx/6060.html
   enum class ModeOfOperation : int8_t {
     ImpedanceMode = -6,
     JointTorqueMode = -5,
@@ -101,6 +102,7 @@ private:
   };
 
   static constexpr StatePattern state_patterns[] = {
+      // https://doc.synapticon.com/circulo/system_integration/status_and_controlword.html
       // mask     value      state
       {0b1001111, 0b0000000, State::NOT_READY_TO_SWITCH_ON},
       {0b1001111, 0b1000000, State::SWITCH_ON_DISABLED},
@@ -118,6 +120,7 @@ private:
   };
 
   static constexpr ControlPattern control_patterns[] = {
+      // https://doc.synapticon.com/circulo/system_integration/status_and_controlword.html
       // mask      value       operation
       {0b10000111, 0b00000110, Operation::SHUTDOWN},
       {0b10001111, 0b00000111, Operation::SWITCH_ON},

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/cia402.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/cia402.hpp
@@ -64,6 +64,22 @@ public:
     FAULT_RESET
   };
 
+  enum class ModeOfOperation : int8_t {
+    ImpedanceMode = -6,
+    JointTorqueMode = -5,
+    SystemIdentificationMode = -4,
+    OpenLoopFieldMode = -3,
+    DiagnosticsMode = -2,
+    CoggingCompensationRecordingMode = -1,
+    ProfilePositionMode = 1,
+    ProfileVelocityMode = 3,
+    TorqueProfileMode = 4,
+    HomingMode = 6,
+    CyclicSyncPositionMode = 8,
+    CyclicSyncVelocityMode = 9,
+    CyclicSyncTorqueMode = 10
+  };
+
   CiA402Motor(CiA402_Inputs *inputs, CiA402_Outputs *outputs);
 
   std::optional<State> get_state() const;
@@ -71,10 +87,12 @@ public:
   bool is_state(State s) const;
   bool is_operation_enabled() const;
   bool is_fault() const;
-  
+
   void to_operation_enabled();
   void reset_fault();
   void set_control_word(Operation op);
+  void set_mode_of_operation(ModeOfOperation m);
+
 private:
   struct StatePattern {
     uint16_t mask;

--- a/rise_motion_dev_ws/src/rise_motion/src/cia402.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/cia402.cpp
@@ -26,6 +26,7 @@ bool CiA402Motor::is_state(State s) const {
 bool CiA402Motor::is_operation_enabled() const {
   return is_state(State::OPERATION_ENABLED);
 }
+
 void CiA402Motor::to_operation_enabled() {
   std::optional<State> s = get_state();
 
@@ -69,6 +70,11 @@ void CiA402Motor::set_control_word(Operation op) {
     }
   }
 }
+
+void CiA402Motor::set_mode_of_operation(CiA402Motor::ModeOfOperation m) {
+  outputs->OpMode = static_cast<int8_t>(m);
+}
+
 std::string CiA402Motor::state_as_string() const {
   std::optional<State> s = get_state();
   if (s == std::nullopt) {

--- a/rise_motion_dev_ws/src/rise_motion/src/cia402.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/cia402.cpp
@@ -1,0 +1,97 @@
+#include <cstdint>
+#include <optional>
+#include <rise_motion/cia402.hpp>
+
+CiA402Motor::CiA402Motor(CiA402_Inputs *inputs, CiA402_Outputs *outputs)
+    : inputs(inputs), outputs(outputs) {}
+
+std::optional<CiA402Motor::State> CiA402Motor::get_state() const {
+  const uint16_t sw = inputs->Statusword;
+  for (const auto &p : state_patterns) {
+    if ((sw & p.mask) == p.value)
+      return p.state;
+  }
+  return std::nullopt;
+}
+
+bool CiA402Motor::is_state(State s) const {
+  std::optional<State> actual_state = get_state();
+  if (actual_state.has_value() && actual_state.value() == s) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+bool CiA402Motor::is_operation_enabled() const {
+  return is_state(State::OPERATION_ENABLED);
+}
+void CiA402Motor::to_operation_enabled() {
+  std::optional<State> s = get_state();
+
+  if (!s.has_value()) {
+    return;
+  }
+
+  std::optional<Operation> next_op = std::nullopt;
+  switch (s.value()) {
+  case State::SWITCH_ON_DISABLED:
+    next_op = Operation::SHUTDOWN;
+    break;
+  case State::READY_TO_SWITCH_ON:
+    next_op = Operation::SWITCH_ON;
+    break;
+  case State::SWITCHED_ON:
+    next_op = Operation::ENABLE_OPERATION;
+    break;
+  case State::OPERATION_ENABLED:
+  case State::QUICK_STOP_ACTIVE:
+  case State::FAULT_REACTION_ACTIVE:
+  case State::FAULT:
+  default:
+    return;
+  }
+
+  if (next_op.has_value()) {
+    set_control_word(next_op.value());
+  }
+}
+
+bool CiA402Motor::is_fault() const { return is_state(State::FAULT); }
+
+void CiA402Motor::reset_fault() { set_control_word(Operation::FAULT_RESET); }
+
+void CiA402Motor::set_control_word(Operation op) {
+  for (auto &p : control_patterns) {
+    if (p.op == op) {
+      outputs->Controlword = (outputs->Controlword & ~p.mask) | p.value;
+      break;
+    }
+  }
+}
+std::string CiA402Motor::state_as_string() const {
+  std::optional<State> s = get_state();
+  if (s == std::nullopt) {
+    return "UNKNOWN";
+  }
+
+  switch (s.value()) {
+  case State::NOT_READY_TO_SWITCH_ON:
+    return "NOT_READY_TO_SWITCH_ON";
+  case State::SWITCH_ON_DISABLED:
+    return "SWITCH_ON_DISABLED";
+  case State::READY_TO_SWITCH_ON:
+    return "READY_TO_SWITCH_ON";
+  case State::SWITCHED_ON:
+    return "SWITCHED_ON";
+  case State::OPERATION_ENABLED:
+    return "OPERATION_ENABLED";
+  case State::QUICK_STOP_ACTIVE:
+    return "QUICK_STOP_ACTIVE";
+  case State::FAULT_REACTION_ACTIVE:
+    return "FAULT_REACTION_ACTIVE";
+  case State::FAULT:
+    return "FAULT";
+  }
+  return "UNKNOWN";
+}


### PR DESCRIPTION
Addresses #41.
This adds a class which can be initialized on a memory region containing a CiA402 data. It can decode the current state and drive the state into the operational state.

An example:
```
while (running) {
 send_processdata();
 receive_processdata();
 CiA402Motor m{ctx.slavelist[1].inputs, ctx.slavelist[1].outputs};
 // Check for fault
 if (m.is_fault()) {
   // handle error 
 }
 if (!m.is_operational()) {
   m.to_operation_enabled();
 }
 cout << "Current state: " << m.state_as_string() << endl;
}
```
