### PR TITLE
Feature #57/#58 Implementation and Integration of C++ SDO Serialization Library

### DIFF
--- a/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
+++ b/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
@@ -14,6 +14,10 @@ include_directories(include)
 
 add_subdirectory(SOEM)
 
+# --- sdo_serializer library ---
+add_library(sdo_serializer_lib INTERFACE)
+target_include_directories(sdo_serializer_lib INTERFACE include)
+
 add_executable(
 	rise_motion_main
 	src/main.cpp
@@ -52,6 +56,7 @@ install(TARGETS
 )
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
   # the following line skips the linter which checks for copyrights
   # comment the line when a copyright and license is added to all source files
   set(ament_cmake_copyright_FOUND TRUE)
@@ -60,6 +65,15 @@ if(BUILD_TESTING)
   # a copyright and license is added to all source files
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
+
+  # --- sdo_serializer test ---
+  ament_add_gtest(test_sdo_serializer
+    test/test_sdo_serializer.cpp
+  )
+  if(TARGET test_sdo_serializer)
+    target_link_libraries(test_sdo_serializer sdo_serializer_lib)
+  endif()
+
 endif()
 
 ament_package()

--- a/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
+++ b/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
@@ -16,7 +16,10 @@ add_subdirectory(SOEM)
 
 # --- sdo_serializer library ---
 add_library(sdo_serializer_lib INTERFACE)
-target_include_directories(sdo_serializer_lib INTERFACE include)
+target_include_directories(sdo_serializer_lib INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 add_executable(
 	rise_motion_main
@@ -75,5 +78,19 @@ if(BUILD_TESTING)
   endif()
 
 endif()
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS sdo_serializer_lib
+  EXPORT export_sdo_serializer_lib
+  INCLUDES DESTINATION include
+)
+
+ament_export_targets(export_sdo_serializer_lib)
+ament_export_include_directories(include)
 
 ament_package()

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/ec_manager.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/ec_manager.hpp
@@ -26,7 +26,7 @@ public:
   bool set_motor_values_apsa(const std::vector<int32_t>& motor_values);
 
   // Wrappers for SOEM ecx_SDOwrite, ecx_SDOread
-  bool sdo_read(uint16 device_id, uint16 index, uint8 subindex, std::vector<uint8>& value);
+  bool sdo_read(uint16 device_id, uint16 index, uint8 subindex, std::vector<uint8>& value, uint8 value_size);
   bool sdo_write(uint16 device_id, uint16 index, uint8 subindex, std::vector<uint8>& value);
 
 private:

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/result.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/result.hpp
@@ -1,0 +1,30 @@
+namespace rise
+{
+    template <typename T, typename E> struct Result
+    {
+        T value{};
+        E error{};
+        bool hasValue = false;
+
+        static Result ok(T v)
+        {
+            Result result;
+            result.value = std::move(v);
+            result.hasValue = true;
+            return result;
+        }
+
+        static Result err(E e)
+        {
+            Result result;
+            result.error = std::move(e);
+            result.hasValue = false;
+            return result;
+        }
+
+        explicit operator bool() const
+        {
+            return hasValue;
+        }
+    };
+}

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -19,7 +19,9 @@ namespace sdo
         None,
         InvalidSize,
         OutOfRange,
-        UnsupportedType
+        UnsupportedType,
+        CallFailed,
+        ServiceUnavailable
     };
 
     struct Error

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -18,7 +18,8 @@ namespace sdo
     {
         None,
         InvalidSize,
-        OutOfRange
+        OutOfRange,
+        UnsupportedType
     };
 
     struct Error
@@ -194,6 +195,36 @@ namespace sdo
         }
     };
 
+    template <std::size_t N> struct WSTRING
+    {
+        std::u16string value;
+
+        WSTRING() = default;
+
+        WSTRING(std::u16string v) : value(std::move(v))
+        {}
+
+        operator std::u16string() const
+        {
+            return value;
+        }
+    };
+
+    template <typename T, std::size_t N> struct ARRAY
+    {
+        std::vector<T> value;
+
+        ARRAY() = default;
+
+        ARRAY(std::vector<T> v) : value(std::move(v))
+        {}
+
+        operator std::vector<T>() const
+        {
+            return value;
+        }
+    };
+
 
     template <typename T> using DeserializeResult = rise::Result<T, sdo::Error>;
     using SerializeResult = rise::Result<std::vector<std::uint8_t>, sdo::Error>;
@@ -243,6 +274,27 @@ namespace sdo
     using UNSIGNED56 = sdo::UInt56;
     using UNSIGNED64 = std::uint64_t;
 
+    using BITARR8   = std::uint8_t;
+    using BITARR16  = std::uint16_t;
+    using BITARR32  = std::uint32_t;
+
+    using BIT1  = std::uint8_t;
+    using BIT2  = std::uint8_t;
+    using BIT3  = std::uint8_t;
+    using BIT4  = std::uint8_t;
+    using BIT5  = std::uint8_t;
+    using BIT6  = std::uint8_t;
+    using BIT7  = std::uint8_t;
+    using BIT8  = std::uint8_t;
+    using BIT9  = std::uint16_t;
+    using BIT10  = std::uint16_t;
+    using BIT11  = std::uint16_t;
+    using BIT12  = std::uint16_t;
+    using BIT13  = std::uint16_t;
+    using BIT14  = std::uint16_t;
+    using BIT15  = std::uint16_t;
+    using BIT16  = std::uint16_t;
+
     using REAL32 = float;
     using REAL64 = double;
 
@@ -251,6 +303,19 @@ namespace sdo
 
     using GUID   = sdo::Guid;
     using DOMAIN = std::vector<std::uint8_t>;
+
+    template <std::size_t T> using VISIBLE_STRING = STRING<T>;
+    template <std::size_t T> using UNICODE_STRING = WSTRING<T>;
+    template <std::size_t N> using OKTET_STRING = ARRAY<std::uint8_t, N>;
+    template <std::size_t N> using ARRAY_OF_USINT = ARRAY<std::uint8_t, N>;
+    template <std::size_t N> using ARRAY_OF_UINT = ARRAY<std::uint16_t, N>;
+    template <std::size_t N> using ARRAY_OF_INT = ARRAY<std::int16_t, N>;
+    template <std::size_t N> using ARRAY_OF_SINT = ARRAY<std::int8_t, N>;
+    template <std::size_t N> using ARRAY_OF_DINT = ARRAY<std::int32_t, N>;
+    template <std::size_t N> using ARRAY_OF_UDINT = ARRAY<std::uint32_t, N>;
+    template <std::size_t N> using ARRAY_OF_BITARR8 = ARRAY<std::uint8_t, N>;
+    template <std::size_t N> using ARRAY_OF_BITARR16 = ARRAY<std::uint16_t, N>;
+    template <std::size_t N> using ARRAY_OF_BITARR32 = ARRAY<std::uint32_t, N>;
 }
 
 
@@ -266,6 +331,32 @@ namespace sdo::helpers
     {
         static constexpr std::size_t size = T;
     };
+
+    template <typename T> struct is_wstring_type : std::false_type {};
+    template <std::size_t T> struct is_wstring_type<sdo::WSTRING<T>> : std::true_type {};
+
+    template <typename T> struct wstring_size;
+    template <std::size_t T>struct wstring_size<sdo::WSTRING<T>>
+    {
+        static constexpr std::size_t size = T;
+    };
+
+    template <typename T> struct is_array_type : std::false_type {};
+    template <typename T, std::size_t N> 
+        struct is_array_type<sdo::ARRAY<T, N>> : std::true_type {};
+        
+    template <typename T> struct array_size;
+    template <typename T, std::size_t N>struct array_size<sdo::ARRAY<T, N>>
+    {
+        static constexpr std::size_t size = N;
+    };
+
+    template <typename T> struct elementType;
+    template <typename T, std::size_t N>struct elementType<sdo::ARRAY<T, N>>
+    {
+        using type = T;
+    };
+
 
     inline std::optional<sdo::Error> check_size(
         const std::vector<std::uint8_t>& blob, std::size_t expectedSize, const char* type)
@@ -337,9 +428,105 @@ namespace sdo
     template <typename T> [[nodiscard]] inline DeserializeResult<T> deserialize(
         const std::vector<std::uint8_t>& blob)
     {
-        if constexpr (sdo::helpers::is_string_type<std::remove_cv_t<std::remove_reference_t<T>>>::value){
-            
-            constexpr std::size_t size = sdo::helpers::string_size<T>::size;
+        using CleanT = std::remove_cv_t<std::remove_reference_t<T>>;
+
+        if constexpr (sdo::helpers::is_array_type<CleanT>::value)
+        {
+            constexpr std::size_t numElements = sdo::helpers::array_size<CleanT>::size;
+            using ElementT = typename sdo::helpers::elementType<CleanT>::type;
+            constexpr std::size_t elementSize = sizeof(ElementT);
+            constexpr std::size_t byteSize = numElements * elementSize;
+
+            if (blob.size() > byteSize || blob.size() % elementSize != 0){
+                return DeserializeResult<T>::err({
+                    ErrorCode::InvalidSize, "deserialize<ARRAY<T, N>>: invalid blob size"});
+            }
+
+            T result{};
+            result.value.reserve(blob.size() / elementSize);
+
+            for (std::size_t i = 0; i < blob.size(); i += elementSize){
+                if constexpr (elementSize == 1){
+                    result.value.push_back(static_cast<ElementT>(blob[i]));
+                }
+                else if constexpr (elementSize == 2){
+                    auto raw = sdo::helpers::to_raw<std::uint16_t>(blob, 2, i);
+                    if (!raw){
+                        return DeserializeResult<T>::err(raw.error);
+                    }
+
+                    result.value.push_back(static_cast<ElementT>(raw.value));
+                }
+                else if constexpr (elementSize == 4){
+                    auto raw = sdo::helpers::to_raw<std::uint32_t>(blob, 4, i);
+                    if (!raw){
+                        return DeserializeResult<T>::err(raw.error);
+                    }
+
+                    if constexpr (std::is_same_v<ElementT, float>){
+                        float element;
+                        std::memcpy(&element, &raw.value, sizeof(element));
+                        result.value.push_back(element);
+                    }
+                    else{
+                        result.value.push_back(static_cast<ElementT>(raw.value));
+                    }
+                }
+                else if constexpr (elementSize == 8){
+                    auto raw = sdo::helpers::to_raw<std::uint64_t>(blob, 8, i);
+                    if (!raw){
+                        return DeserializeResult<T>::err(raw.error);
+                    }
+
+                    if constexpr (std::is_same_v<ElementT, double>){
+                        double element;
+                        std::memcpy(&element, &raw.value, sizeof(element));
+                        result.value.push_back(element);
+                    }
+                    else{
+                        result.value.push_back(static_cast<ElementT>(raw.value));
+                    }
+                }
+                else{
+                    return DeserializeResult<T>::err({
+                        ErrorCode::UnsupportedType,
+                        "deserialize<ARRAY<T, N>>: unsupported array type"});
+                }
+            }
+
+            return DeserializeResult<T>::ok(std::move(result));
+        }
+        else if constexpr (sdo::helpers::is_wstring_type<CleanT>::value)
+        {
+            constexpr std::size_t size = sdo::helpers::wstring_size<CleanT>::size;
+
+            if (blob.size() > size * 2 || blob.size() % 2 != 0){
+                return DeserializeResult<T>::err({
+                    ErrorCode::InvalidSize,
+                    "deserialize<WSTRING<T>>: blob is larger than the expected size T"});
+            }
+
+            T str{};
+
+            for (std::size_t i = 0; i < blob.size(); i += 2){
+                std::uint16_t raw = 
+                    static_cast<std::uint16_t>(blob[i]) |
+                    static_cast<std::uint16_t>(blob[i + 1]) << 8;
+
+                str.value.push_back(static_cast<char16_t>(raw));
+            }
+
+            // strip padding zeros
+            while (!str.value.empty() && str.value.back() == u'\0'){
+                str.value.pop_back();
+            }
+
+            return DeserializeResult<T>::ok(str);
+        }
+        else if constexpr (sdo::helpers::is_string_type<CleanT>::value)
+        {
+        
+            constexpr std::size_t size = sdo::helpers::string_size<CleanT>::size;
 
             if (blob.size() > size){
                 return DeserializeResult<T>::err({
@@ -347,16 +534,16 @@ namespace sdo
                     "deserialize<STRING<T>>: blob is larger than the expected size T"});
             }
 
-            T string{};
+            T str{};
 
-            string.value.assign(blob.begin(), blob.end());
+            str.value.assign(blob.begin(), blob.end());
 
             // strip padding zeros
-            while (!string.value.empty() && string.value.back() == '\0'){
-                string.value.pop_back();
+            while (!str.value.empty() && str.value.back() == '\0'){
+                str.value.pop_back();
             }
 
-            return DeserializeResult<T>::ok(string);
+            return DeserializeResult<T>::ok(str);
         }
         else{
             static_assert(sdo::helpers::always_false<T>, "deserialize<T>: unsupported type");
@@ -746,7 +933,109 @@ namespace sdo
 
     template <typename T> SerializeResult serialize(const T& value)
     {
-        if constexpr (sdo::helpers::is_string_type<std::remove_cv_t<std::remove_reference_t<T>>>::value){
+        using CleanT = std::remove_cv_t<std::remove_reference_t<T>>;
+
+        if constexpr (sdo::helpers::is_array_type<CleanT>::value)
+        {
+            constexpr std::size_t numElements = sdo::helpers::array_size<CleanT>::size;
+            using ElementT = typename sdo::helpers::elementType<CleanT>::type;
+            constexpr std::size_t elementSize = sizeof(ElementT);
+            constexpr std::size_t byteSize = numElements * elementSize;
+
+            if (value.value.size() > numElements){
+                return SerializeResult::err({
+                    ErrorCode::OutOfRange,
+                    "serialize<ARRAY<T, N>>: array is longer than size N"
+                });
+            }
+
+            std::vector<std::uint8_t> blob;
+            blob.reserve(byteSize);
+
+            for (const auto& element : value.value){
+                if constexpr (elementSize == 1){
+                    const auto raw = static_cast<std::uint8_t>(element);
+
+                    blob.push_back(raw);
+                }
+                else if constexpr (elementSize == 2){
+                    const auto raw = static_cast<std::uint16_t>(element);
+
+                    blob.push_back(static_cast<std::uint8_t>(raw & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 8) & 0xFF));
+                }
+                else if constexpr (elementSize == 4){
+                    std::uint32_t raw;
+
+                    if constexpr (std::is_same_v<ElementT, float>){
+                        std::memcpy(&raw, &element, sizeof(raw));
+                    }
+                    else{
+                        raw = static_cast<std::uint32_t>(element);
+                    }
+
+                    blob.push_back(static_cast<std::uint8_t>(raw & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 8) & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 16) & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 24) & 0xFF));
+                }
+                else if constexpr (elementSize == 8){
+                    std::uint64_t raw;
+
+                    if constexpr (std::is_same_v<ElementT, double>){
+                        std::memcpy(&raw, &element, sizeof(raw));
+                    }
+                    else{
+                        raw = static_cast<std::uint64_t>(element);
+                    }
+
+                    blob.push_back(static_cast<std::uint8_t>(raw & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 8) & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 16) & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 24) & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 32) & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 40) & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 48) & 0xFF));
+                    blob.push_back(static_cast<std::uint8_t>((raw >> 56) & 0xFF));
+                }
+                else{
+                    return SerializeResult::err({
+                        ErrorCode::UnsupportedType,
+                        "serialize<ARRAY<T, N>>: unsupported array type"});
+                }
+            }
+
+            blob.resize(byteSize, 0);
+
+            return SerializeResult::ok(std::move(blob));
+        }
+        else if constexpr (sdo::helpers::is_wstring_type<CleanT>::value)
+        {
+            constexpr std::size_t size = sdo::helpers::wstring_size<CleanT>::size;
+
+            if (value.value.size() > size)
+            {
+                return SerializeResult::err({
+                    ErrorCode::InvalidSize, "serialize<WSTRING<T>>: string is longer than size T"});
+            }
+
+            std::vector<std::uint8_t> blob;
+            blob.reserve(size * 2);
+
+            for (char16_t c : value.value)
+            {
+                std::uint16_t raw = static_cast<std::uint16_t>(c);
+
+                blob.push_back(static_cast<std::uint8_t>(raw & 0xFF));
+                blob.push_back(static_cast<std::uint8_t>((raw >> 8) & 0xFF));
+            }
+
+            blob.resize(size * 2, '\0');
+
+            return SerializeResult::ok(std::move(blob));
+        }
+        else if constexpr (sdo::helpers::is_string_type<CleanT>::value)
+        {
 
             constexpr std::size_t size = sdo::helpers::string_size<T>::size;
 

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -10,14 +10,31 @@
 #include <cstring>
 #include <cstddef>
 #include <cmath>
+#include "result.hpp"
 
 namespace sdo
 {
+    enum class ErrorCode
+    {
+        None,
+        InvalidSize,
+        OutOfRange
+    };
+
+    struct Error
+    {
+        ErrorCode code = ErrorCode::None;
+        std::string message = "";
+    };
+
+
     // as equivalent of the EtherCAT TIME_OF_DAY data type
     struct TimeOfDay
     {
         std::uint32_t ms_since_midnight;
         std::uint16_t d_since_1984_01_01;
+
+        TimeOfDay() = default;
     };
 
     // as equivalent of the EtherCAT TIME_DIFFERENCE data type
@@ -25,18 +42,18 @@ namespace sdo
     {
         std::uint32_t ms;
         std::uint16_t d;
+
+        TimeDifference() = default;
     };
 
     struct Int24
     {
         std::int32_t value;
 
+        Int24() = default;
+
         Int24(std::int32_t v) : value(v)
-        {
-            if (v < -pow(2, 23) || v > pow(2, 23)-1){
-                throw std::out_of_range("Can not convert int32_t value exceeding 24 bit signed range into Int24");
-            }
-        }
+        {}
 
         operator std::int32_t() const
         {
@@ -48,12 +65,10 @@ namespace sdo
     {
         std::int64_t value;
 
+        Int40() = default;
+
         Int40(std::int64_t v) : value(v)
-        {
-            if (v < -pow(2, 39) || v > pow(2, 39)-1){
-                throw std::out_of_range("Can not convert int64_t value exceeding 40 bit signed range into Int40");
-            }
-        }
+        {}
 
         operator std::int64_t() const
         {
@@ -65,12 +80,10 @@ namespace sdo
     {
         std::int64_t value;
 
+        Int48() = default;
+
         Int48(std::int64_t v) : value(v)
-        {
-            if (v < -pow(2, 47) || v > pow(2, 47)-1){
-                throw std::out_of_range("Can not convert int64_t value exceeding 48 bit signed range into Int48");
-            }
-        }
+        {}
 
         operator std::int64_t() const
         {
@@ -82,12 +95,10 @@ namespace sdo
     {
         std::int64_t value;
 
+        Int56() = default;
+
         Int56(std::int64_t v) : value(v)
-        {
-            if (v < -pow(2, 55) || v > pow(2, 55)-1){
-                throw std::out_of_range("Can not convert int64_t value exceeding 56 bit signed range into Int56");
-            }
-        }
+        {}
 
         operator std::int64_t() const
         {
@@ -99,12 +110,10 @@ namespace sdo
     {
         std::uint32_t value;
 
+        UInt24() = default;
+
         UInt24(std::uint32_t v) : value(v)
-        {
-            if (v > pow(2, 24)-1){
-                throw std::out_of_range("Can not convert uint32_t value exceeding 24 bit unsigned range into UInt24");
-            }
-        }
+        {}
 
         operator std::uint32_t() const
         {
@@ -116,12 +125,10 @@ namespace sdo
     {
         std::uint64_t value;
 
+        UInt40() = default;
+
         UInt40(std::uint64_t v) : value(v)
-        {
-            if (v > pow(2, 40)-1){
-                throw std::out_of_range("Can not convert uint64_t value exceeding 40 bit unsigned range into UInt40");
-            }
-        }
+        {}
 
         operator std::uint64_t() const
         {
@@ -133,12 +140,10 @@ namespace sdo
     {
         std::uint64_t value;
 
+        UInt48() = default;
+
         UInt48(std::uint64_t v) : value(v)
-        {
-            if (v > pow(2, 48)-1){
-                throw std::out_of_range("Can not convert uint64_t value exceeding 48 bit unsigned range into UInt48");
-            }
-        }
+        {}
 
         operator std::uint64_t() const
         {
@@ -150,12 +155,10 @@ namespace sdo
     {
         std::uint64_t value;
 
+        UInt56() = default;
+
         UInt56(std::uint64_t v) : value(v)
-        {
-            if (v > pow(2, 56)-1){
-                throw std::out_of_range("Can not convert uint64_t value exceeding 56 bit unsigned range into UInt56");
-            }
-        }
+        {}
 
         operator std::uint64_t() const
         {
@@ -183,11 +186,7 @@ namespace sdo
         STRING() = default;
 
         STRING(std::string v) : value(std::move(v))
-        {
-            if (value.size() > T){
-                throw std::out_of_range("STRING<T>: string is too long to be coverted to STRING<T> of size T");
-            }
-        };
+        {}
 
         operator std::string() const
         {
@@ -195,6 +194,9 @@ namespace sdo
         }
     };
 
+
+    template <typename T> using DeserializeResult = rise::Result<T, sdo::Error>;
+    using SerializeResult = rise::Result<std::vector<std::uint8_t>, sdo::Error>;
 
     // IEC 61131-3 data types
     using BOOL  = bool;
@@ -265,15 +267,20 @@ namespace sdo::helpers
         static constexpr std::size_t size = T;
     };
 
-    inline void check_size(const std::vector<std::uint8_t>& blob, std::size_t expectedSize, const char* type)
+    inline std::optional<sdo::Error> check_size(
+        const std::vector<std::uint8_t>& blob, std::size_t expectedSize, const char* type)
     {
         if (blob.size() != expectedSize){
-            throw std::invalid_argument(std::string("deserialize<") + type + ">: expected " + 
-                std::to_string(expectedSize) + " bytes, got " + std::to_string(blob.size()));
+            return Error{
+                ErrorCode::InvalidSize,
+                std::string("deserialize<") + type + ">: expected " + std::to_string(expectedSize) +
+                " bytes, got " + std::to_string(blob.size())};
         }
+
+        return std::nullopt;
     }
 
-    template <typename T> [[nodiscard]] inline T to_raw(
+    template <typename T> [[nodiscard]] inline DeserializeResult<T> to_raw(
         const std::vector<std::uint8_t>& blob, std::size_t numBytes, std::size_t offset = 0)
     {
         static_assert(std::is_unsigned_v<T>, "to_raw<T>: T must be unsigned");
@@ -281,12 +288,14 @@ namespace sdo::helpers
 
         if (numBytes > sizeof(T))
         {
-            throw std::invalid_argument("to_raw<T>: numBytes does not fit T");
+            return DeserializeResult<T>::err({
+                ErrorCode::InvalidSize, "to_raw<T>: numBytes does not fit T"});
         }
 
         if (offset + numBytes > blob.size())
         {
-            throw std::out_of_range("to_raw<T>: blob has less bytes than numBytes");
+            return DeserializeResult<T>::err({
+                ErrorCode::InvalidSize, "to_raw<T>: blob has less bytes than numBytes"});
         }
 
         T raw = 0;
@@ -296,16 +305,17 @@ namespace sdo::helpers
             raw |= static_cast<T>(blob[offset + i]) << (8 * i);
         }
 
-        return raw;
+        return DeserializeResult<T>::ok(raw);
     }
 
-    template <typename T> [[nodiscard]] inline std::vector<std::uint8_t> from_raw(const T& raw, std::size_t numBytes)
+    template <typename T> [[nodiscard]] inline SerializeResult from_raw(
+        const T& raw, std::size_t numBytes)
     {
         static_assert(std::is_unsigned_v<T>, "from_raw<T>: T must be unsigned");
 
         if (numBytes > sizeof(T))
         {
-            throw std::invalid_argument("from_raw<T>: numBytes does not fit T");
+            SerializeResult::err({ErrorCode::InvalidSize, "from_raw<T>: numBytes does not fit T"});
         }
 
         std::vector<std::uint8_t> blob;
@@ -316,7 +326,7 @@ namespace sdo::helpers
             blob.push_back(static_cast<std::uint8_t>((raw >> (8 * i)) & 0xFF));
         }
 
-        return blob;
+        return SerializeResult::ok(blob);
     }
 }
 
@@ -324,14 +334,17 @@ namespace sdo
 {
     // ---DESERIALIZATION---
 
-    template <typename T> T deserialize(const std::vector<std::uint8_t>& blob)
+    template <typename T> [[nodiscard]] inline DeserializeResult<T> deserialize(
+        const std::vector<std::uint8_t>& blob)
     {
         if constexpr (sdo::helpers::is_string_type<std::remove_cv_t<std::remove_reference_t<T>>>::value){
             
             constexpr std::size_t size = sdo::helpers::string_size<T>::size;
 
             if (blob.size() > size){
-                throw std::invalid_argument("deserialize<STRING<T>>: blob is larger than the expected size T");
+                return DeserializeResult<T>::err({
+                    ErrorCode::InvalidSize, 
+                    "deserialize<STRING<T>>: blob is larger than the expected size T"});
             }
 
             T string{};
@@ -343,7 +356,7 @@ namespace sdo
                 string.value.pop_back();
             }
 
-            return string;
+            return DeserializeResult<T>::ok(string);
         }
         else{
             static_assert(sdo::helpers::always_false<T>, "deserialize<T>: unsupported type");
@@ -352,235 +365,371 @@ namespace sdo
 
     // -Boolean-
 
-    template <> [[nodiscard]] inline bool deserialize<bool>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<bool> deserialize<bool>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 1, "bool");
+        if (auto error = sdo::helpers::check_size(blob, 1, "bool")){
+            return sdo::DeserializeResult<bool>::err(*error);
+        }
 
-        return blob[0] != 0;
+        return DeserializeResult<bool>::ok(blob[0] != 0);
     }
 
     // -Signed Integer-
 
-    template <> [[nodiscard]] inline std::int8_t deserialize<std::int8_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<std::int8_t> deserialize<std::int8_t>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 1, "int8_t");
+        if (auto error = sdo::helpers::check_size(blob, 1, "int8_t")){
+            return sdo::DeserializeResult<std::int8_t>::err(*error);
+        }
 
-        return static_cast<std::int8_t>(blob[0]);
+        return DeserializeResult<std::int8_t>::ok(static_cast<std::int8_t>(blob[0]));
     }
 
-    template <> [[nodiscard]] inline std::int16_t deserialize<std::int16_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<std::int16_t> deserialize<std::int16_t>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 2, "int16_t");
+        if (auto error = sdo::helpers::check_size(blob, 2, "int16_t")){
+            return sdo::DeserializeResult<std::int16_t>::err(*error);
+        }
 
-        std::int16_t value = static_cast<std::int16_t>(sdo::helpers::to_raw<std::uint16_t>(blob, 2));
+        auto raw = sdo::helpers::to_raw<std::uint16_t>(blob, 2);
+        if(!raw){
+            return DeserializeResult<std::int16_t>::err(raw.error);
+        }
 
-        return value;
+        auto result = static_cast<std::int16_t>(raw.value);
+
+        return DeserializeResult<std::int16_t>::ok(result);
     }
 
-    template <> [[nodiscard]] inline std::int32_t deserialize<std::int32_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<std::int32_t> deserialize<std::int32_t>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 4, "int32_t");
+        if (auto error = sdo::helpers::check_size(blob, 4, "int32_t")){
+            return sdo::DeserializeResult<std::int32_t>::err(*error);
+        }
 
-        std::int32_t value = static_cast<std::int32_t>(sdo::helpers::to_raw<std::uint32_t>(blob, 4));
+        auto raw = sdo::helpers::to_raw<std::uint32_t>(blob, 4);
+        if(!raw){
+            return DeserializeResult<std::int32_t>::err(raw.error);
+        }
 
-        return value;
+        auto result = static_cast<std::int32_t>(raw.value);
+
+        return DeserializeResult<std::int32_t>::ok(result);
     }
 
     // -Unsigned Integer / raw data / bit arrays / bit strings-
 
     // use for UNSIGNED8, BYTE, BITARR8, BIT1-BIT8
-    template <> [[nodiscard]] inline std::uint8_t deserialize<std::uint8_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<std::uint8_t> deserialize<std::uint8_t>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 1, "uint8_t");
+        if (auto error = sdo::helpers::check_size(blob, 1, "uint8_t")){
+            return sdo::DeserializeResult<std::uint8_t>::err(*error);
+        }
 
-        return static_cast<std::uint8_t>(blob[0]);
+        return DeserializeResult<std::uint8_t>::ok(static_cast<std::uint8_t>(blob[0]));
     }
 
     // use for UNSIGNED16, WORD, BITARR16, BIT9-BIT16
-    template <> [[nodiscard]] inline std::uint16_t deserialize<std::uint16_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<std::uint16_t> deserialize<std::uint16_t>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 2, "uint16_t");
+        if (auto error = sdo::helpers::check_size(blob, 2, "uint16_t")){
+            return sdo::DeserializeResult<std::uint16_t>::err(*error);
+        }
 
         return sdo::helpers::to_raw<std::uint16_t>(blob, 2);
     }
 
     // use for UNSIGNED32, DWORD, BITARR32
-    template <> [[nodiscard]] inline std::uint32_t deserialize<std::uint32_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<std::uint32_t> deserialize<std::uint32_t>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 4, "uint32_t");
+        if (auto error = sdo::helpers::check_size(blob, 4, "uint32_t")){
+            return sdo::DeserializeResult<std::uint32_t>::err(*error);
+        }
 
         return sdo::helpers::to_raw<std::uint32_t>(blob, 4);
     }
 
     // -Floating Point-
 
-    template <> [[nodiscard]] inline float deserialize<float>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<float> deserialize<float>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 4, "float");
+        if (auto error = sdo::helpers::check_size(blob, 4, "float")){
+            return sdo::DeserializeResult<float>::err(*error);
+        }
 
-        std::uint32_t raw = sdo::helpers::to_raw<std::uint32_t>(blob, 4);
+        auto raw = sdo::helpers::to_raw<std::uint32_t>(blob, 4);
+        if(!raw){
+            return DeserializeResult<float>::err(raw.error);
+        }
 
         float value;
-        std::memcpy(&value, &raw, sizeof(value));
+        std::memcpy(&value, &raw.value, sizeof(value));
 
-        return value;
+        return DeserializeResult<float>::ok(value);
     }
 
-    template <> [[nodiscard]] inline double deserialize<double>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<double> deserialize<double>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 8, "double");
+        if (auto error = sdo::helpers::check_size(blob, 8, "double")){
+            return sdo::DeserializeResult<double>::err(*error);
+        }
 
-        std::uint64_t raw = sdo::helpers::to_raw<std::uint64_t>(blob, 8);
+        auto raw = sdo::helpers::to_raw<std::uint64_t>(blob, 8);
+        if(!raw){
+            return DeserializeResult<double>::err(raw.error);
+        }
 
         double value;
-        std::memcpy(&value, &raw, sizeof(value));
+        std::memcpy(&value, &raw.value, sizeof(value));
 
-        return value;
+        return DeserializeResult<double>::ok(value);
     }
 
     // -Time-
 
-    template <> [[nodiscard]] inline TimeOfDay deserialize<TimeOfDay>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<TimeOfDay> deserialize<TimeOfDay>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 6, "TimeOfDay");
+        if (auto error = sdo::helpers::check_size(blob, 6, "TimeOfDay")){
+            return sdo::DeserializeResult<TimeOfDay>::err(*error);
+        }
 
         TimeOfDay value{};
 
-        value.ms_since_midnight = sdo::helpers::to_raw<std::uint32_t>(blob, 4);
-        value.d_since_1984_01_01 = sdo::helpers::to_raw<std::uint16_t>(blob, 2, 4);
+        auto ms_raw = sdo::helpers::to_raw<std::uint32_t>(blob, 4);
+        if(!ms_raw){
+            return DeserializeResult<TimeOfDay>::err(ms_raw.error);
+        }
+        value.ms_since_midnight = ms_raw.value;
 
-        return value;
+        auto d_raw = sdo::helpers::to_raw<std::uint16_t>(blob, 2, 4);
+        if(!d_raw){
+            return DeserializeResult<TimeOfDay>::err(d_raw.error);
+        }
+        value.d_since_1984_01_01 = d_raw.value;
+
+        return DeserializeResult<TimeOfDay>::ok(value);
     }
 
-    template <> [[nodiscard]] inline TimeDifference deserialize<TimeDifference>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<TimeDifference> deserialize<TimeDifference>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 6, "TimeDifference");
+        if (auto error = sdo::helpers::check_size(blob, 6, "TimeDifference")){
+            return sdo::DeserializeResult<TimeDifference>::err(*error);
+        }
 
         TimeDifference value{};
 
+        auto ms_raw =  sdo::helpers::to_raw<std::uint32_t>(blob, 4);
+        if(!ms_raw){
+            return DeserializeResult<TimeDifference>::err(ms_raw.error);
+        }
         // the upper 4 bits of ms are reserved
-        value.ms = sdo::helpers::to_raw<std::uint32_t>(blob, 4) & 0x0FFFFFFF;
+        value.ms =  ms_raw.value & 0x0FFFFFFF;
 
-        value.d = sdo::helpers::to_raw<std::uint16_t>(blob, 2, 4);
+        auto d_raw = sdo::helpers::to_raw<std::uint16_t>(blob, 2, 4);
+        if(!d_raw){
+            return DeserializeResult<TimeDifference>::err(d_raw.error);
+        }
+        value.d = d_raw.value;
 
-        return value;
+        return DeserializeResult<TimeDifference>::ok(value);
     }
 
     // -Domain-
     // (returns raw blob as equivalent to the EtherCAT Domain data type)
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> deserialize<std::vector<std::uint8_t>>(
+    template <> [[nodiscard]] inline DeserializeResult<std::vector<std::uint8_t>> deserialize<std::vector<std::uint8_t>>(
         const std::vector<std::uint8_t>& blob)
     {
-        return blob;
+        return DeserializeResult<std::vector<std::uint8_t>>::ok(blob);
     }
 
     // -Extended Signed Integer-
 
-    template <> [[nodiscard]] inline Int24 deserialize<Int24>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<Int24> deserialize<Int24>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 3, "Int24");
-
-        std::uint32_t raw = sdo::helpers::to_raw<std::uint32_t>(blob, 3);
-
-        if (raw & 0x00800000){
-            raw |= 0xFF000000;
+        if (auto error = sdo::helpers::check_size(blob, 3, "Int24")){
+            return sdo::DeserializeResult<Int24>::err(*error);
         }
 
-        return Int24{static_cast<std::int32_t>(raw)};
+        auto raw = sdo::helpers::to_raw<std::uint32_t>(blob, 3);
+        if(!raw){
+            return DeserializeResult<Int24>::err(raw.error);
+        }
+
+        if (raw.value & 0x00800000){
+            raw.value |= 0xFF000000;
+        }
+
+        return DeserializeResult<Int24>::ok(Int24{static_cast<std::int32_t>(raw.value)});
     }
 
-    template <> [[nodiscard]] inline Int40 deserialize<Int40>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<Int40> deserialize<Int40>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 5, "Int40");
+        if (auto error = sdo::helpers::check_size(blob, 5, "Int40")){
+            return sdo::DeserializeResult<Int40>::err(*error);
+        }
 
-        std::uint64_t raw = sdo::helpers::to_raw<std::uint64_t>(blob, 5);
+        auto raw = sdo::helpers::to_raw<std::uint64_t>(blob, 5);
+        if(!raw){
+            return DeserializeResult<Int40>::err(raw.error);
+        }
 
-        if (raw & 0x0000008000000000ULL)
+        if (raw.value & 0x0000008000000000ULL)
         {
-            raw |= 0xFFFFFF0000000000ULL;
+            raw.value |= 0xFFFFFF0000000000ULL;
         }
 
-        return Int40{static_cast<std::int64_t>(raw)};
+        return DeserializeResult<Int40>::ok(Int40{static_cast<std::int64_t>(raw.value)});
     }
 
-    template <> [[nodiscard]] inline Int48 deserialize<Int48>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<Int48> deserialize<Int48>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 6, "Int48");
+        if (auto error = sdo::helpers::check_size(blob, 6, "Int48")){
+            return sdo::DeserializeResult<Int48>::err(*error);
+        }
 
-        std::uint64_t raw = sdo::helpers::to_raw<std::uint64_t>(blob, 6);
+        auto raw = sdo::helpers::to_raw<std::uint64_t>(blob, 6);
+        if(!raw){
+            return DeserializeResult<Int48>::err(raw.error);
+        }
 
-        if (raw & 0x0000800000000000ULL)
+        if (raw.value & 0x0000800000000000ULL)
         {
-            raw |= 0xFFFF000000000000ULL;
+            raw.value |= 0xFFFF000000000000ULL;
         }
 
-        return Int48{static_cast<std::int64_t>(raw)};
+        return DeserializeResult<Int48>::ok(Int48{static_cast<std::int64_t>(raw.value)});
     }
 
-    template <> [[nodiscard]] inline Int56 deserialize<Int56>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<Int56> deserialize<Int56>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 7, "Int56");
+        if (auto error = sdo::helpers::check_size(blob, 7, "Int56")){
+            return sdo::DeserializeResult<Int56>::err(*error);
+        }
 
-        std::uint64_t raw = sdo::helpers::to_raw<std::uint64_t>(blob, 7);
+        auto raw = sdo::helpers::to_raw<std::uint64_t>(blob, 7);
+        if(!raw){
+            return DeserializeResult<Int56>::err(raw.error);
+        }
 
-        if (raw & 0x0080000000000000ULL)
+        if (raw.value & 0x0080000000000000ULL)
         {
-            raw |= 0xFF00000000000000ULL;
+            raw.value |= 0xFF00000000000000ULL;
         }
 
-        return Int56{static_cast<std::int64_t>(raw)};
+        return DeserializeResult<Int56>::ok(Int56{static_cast<std::int64_t>(raw.value)});
     }
 
-    template <> [[nodiscard]] inline std::int64_t deserialize<std::int64_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<std::int64_t> deserialize<std::int64_t>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 8, "int64_t");
+        if (auto error = sdo::helpers::check_size(blob, 8, "int64_t")){
+            return sdo::DeserializeResult<std::int64_t>::err(*error);
+        }
 
-        return static_cast<std::int64_t>(sdo::helpers::to_raw<std::uint64_t>(blob, 8));
+        auto raw = sdo::helpers::to_raw<std::uint64_t>(blob, 8);
+        if(!raw){
+            return DeserializeResult<std::int64_t>::err(raw.error);
+        }
+
+        return DeserializeResult<std::int64_t>::ok(static_cast<std::int64_t>(raw.value));
     }
 
     // -Extended Unsigned Integer-
 
-    template <> [[nodiscard]] inline UInt24 deserialize<UInt24>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<UInt24> deserialize<UInt24>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 3, "UInt24");
+        if (auto error = sdo::helpers::check_size(blob, 3, "UInt24")){
+            return sdo::DeserializeResult<UInt24>::err(*error);
+        }
 
-        return UInt24{sdo::helpers::to_raw<std::uint32_t>(blob, 3)};
+        auto raw = sdo::helpers::to_raw<std::uint32_t>(blob, 3);
+        if(!raw){
+            return DeserializeResult<UInt24>::err(raw.error);
+        }
+
+        return DeserializeResult<UInt24>::ok(UInt24{raw.value});
     }
 
-    template <> [[nodiscard]] inline UInt40 deserialize<UInt40>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<UInt40> deserialize<UInt40>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 5, "UInt40");
+        if (auto error = sdo::helpers::check_size(blob, 5, "UInt40")){
+            return sdo::DeserializeResult<UInt40>::err(*error);
+        }
 
-        return UInt40{sdo::helpers::to_raw<std::uint64_t>(blob, 5)};
+        auto raw = sdo::helpers::to_raw<std::uint64_t>(blob, 5);
+        if(!raw){
+            return DeserializeResult<UInt40>::err(raw.error);
+        }
+
+        return DeserializeResult<UInt40>::ok(UInt40{raw.value});
     }
 
-    template <> [[nodiscard]] inline UInt48 deserialize<UInt48>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<UInt48> deserialize<UInt48>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 6, "UInt48");
+        if (auto error = sdo::helpers::check_size(blob, 6, "UInt48")){
+            return sdo::DeserializeResult<UInt48>::err(*error);
+        }
 
-        return UInt48{sdo::helpers::to_raw<std::uint64_t>(blob, 6)};
+        auto raw = sdo::helpers::to_raw<std::uint64_t>(blob, 6);
+        if(!raw){
+            return DeserializeResult<UInt48>::err(raw.error);
+        }
+
+        return DeserializeResult<UInt48>::ok(UInt48{raw.value});
     }
 
-    template <> [[nodiscard]] inline UInt56 deserialize<UInt56>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<UInt56> deserialize<UInt56>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 7, "UInt56");
+        if (auto error = sdo::helpers::check_size(blob, 7, "UInt56")){
+            return sdo::DeserializeResult<UInt56>::err(*error);
+        }
 
-        return UInt56{sdo::helpers::to_raw<std::uint64_t>(blob, 7)};
+        auto raw = sdo::helpers::to_raw<std::uint64_t>(blob, 7);
+        if(!raw){
+            return DeserializeResult<UInt56>::err(raw.error);
+        }
+
+        return DeserializeResult<UInt56>::ok(UInt56{raw.value});
     }
 
-    template <> [[nodiscard]] inline std::uint64_t deserialize<std::uint64_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<std::uint64_t> deserialize<std::uint64_t>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 8, "uint64_t");
+        if (auto error = sdo::helpers::check_size(blob, 8, "uint64_t")){
+            return sdo::DeserializeResult<std::uint64_t>::err(*error);
+        }
 
         return sdo::helpers::to_raw<std::uint64_t>(blob, 8);
     }
 
     // -GUID-
 
-    template <> [[nodiscard]] inline Guid deserialize<Guid>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline DeserializeResult<Guid> deserialize<Guid>(
+        const std::vector<std::uint8_t>& blob)
     {
-        sdo::helpers::check_size(blob, 16, "Guid");
+        if (auto error = sdo::helpers::check_size(blob, 16, "Guid")){
+            return sdo::DeserializeResult<Guid>::err(*error);
+        }
 
         Guid value{};
 
@@ -589,26 +738,27 @@ namespace sdo
             value.bytes[i] = blob[i];
         }
 
-        return value;
+        return DeserializeResult<Guid>::ok(value);
     }
 
 
     // ---SERIALIZATION---
 
-    template <typename T> std::vector<std::uint8_t> serialize(const T& value)
+    template <typename T> SerializeResult serialize(const T& value)
     {
         if constexpr (sdo::helpers::is_string_type<std::remove_cv_t<std::remove_reference_t<T>>>::value){
 
             constexpr std::size_t size = sdo::helpers::string_size<T>::size;
 
             if (value.value.size() > size){
-                throw std::out_of_range("serialize<STRING<T>>: string is longer than size T");
+                return SerializeResult::err({
+                    ErrorCode::InvalidSize, "serialize<STRING<T>>: string is longer than size T"});
             }
 
             std::vector<std::uint8_t> blob(value.value.begin(), value.value.end());
             blob.resize(size, '\0');
 
-            return blob;
+            return SerializeResult::ok(blob);
         }
         else{
             static_assert(sdo::helpers::always_false<T>, "serialize<T>: unsupported type");
@@ -618,24 +768,24 @@ namespace sdo
 
     // -Boolean-
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<bool>(const bool& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<bool>(const bool& value)
     {
-        return {static_cast<std::uint8_t>(value ? 1 : 0)};
+        return SerializeResult::ok({static_cast<std::uint8_t>(value ? 1 : 0)});
     }
 
     // -Signed Integer-
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::int8_t>(const std::int8_t& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<std::int8_t>(const std::int8_t& value)
     {
-        return {static_cast<std::uint8_t>(value)};
+        return SerializeResult::ok({static_cast<std::uint8_t>(value)});
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::int16_t>(const std::int16_t& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<std::int16_t>(const std::int16_t& value)
     {
         return sdo::helpers::from_raw<std::uint16_t>(static_cast<std::uint16_t>(value), 2);
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::int32_t>(const std::int32_t& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<std::int32_t>(const std::int32_t& value)
     {
         return sdo::helpers::from_raw<std::uint32_t>(static_cast<std::uint32_t>(value), 4);
     }
@@ -643,27 +793,27 @@ namespace sdo
     // -Unsigned Integer / raw data / bit arrays / bit strings-
 
     // use for UNSIGNED8, BYTE, BITARR8, BIT1-BIT8
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::uint8_t>(const std::uint8_t& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<std::uint8_t>(const std::uint8_t& value)
     {
-        return { value };
+        return SerializeResult::ok({value});
     }
 
     // use for UNSIGNED16, WORD, BITARR16, BIT9-BIT16
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::uint16_t>(const std::uint16_t& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<std::uint16_t>(const std::uint16_t& value)
     {
         return sdo::helpers::from_raw<std::uint16_t>(value, 2);
     }
 
     // use for UNSIGNED32, DWORD, BITARR32
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::uint32_t>(const std::uint32_t& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<std::uint32_t>(const std::uint32_t& value)
     {
         return sdo::helpers::from_raw<std::uint32_t>(value, 4);
     }
 
     // -Floating Point-
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<float>(const float& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<float>(const float& value)
     {
         std::uint32_t raw;
         std::memcpy(&raw, &value, sizeof(raw));
@@ -671,7 +821,7 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint32_t>(raw, 4);
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<double>(const double& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<double>(const double& value)
     {
         std::uint64_t raw;
         std::memcpy(&raw, &value, sizeof(raw));
@@ -681,9 +831,9 @@ namespace sdo
 
     // -Time-
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<TimeOfDay>(const TimeOfDay& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<TimeOfDay>(const TimeOfDay& value)
     {
-        return {
+        return SerializeResult::ok({
             static_cast<std::uint8_t>(value.ms_since_midnight & 0xFF),
             static_cast<std::uint8_t>((value.ms_since_midnight >> 8) & 0xFF),
             static_cast<std::uint8_t>((value.ms_since_midnight >> 16) & 0xFF),
@@ -691,17 +841,19 @@ namespace sdo
 
             static_cast<std::uint8_t>(value.d_since_1984_01_01 & 0xFF),
             static_cast<std::uint8_t>((value.d_since_1984_01_01 >> 8) & 0xFF)
-        };
+        });
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<TimeDifference>(const TimeDifference& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<TimeDifference>(const TimeDifference& value)
     {
         if (value.ms > 0x0FFFFFFF)
         {
-            throw std::out_of_range("serialize<TimeDifference>: TimeDifference.ms exceeds 28 bit range");
+            SerializeResult::err({
+                ErrorCode::OutOfRange, 
+                "serialize<TimeDifference>: TimeDifference.ms exceeds 28 bit range"});
         }
 
-        return {
+        return SerializeResult::ok({
             static_cast<std::uint8_t>(value.ms & 0xFF),
             static_cast<std::uint8_t>((value.ms >> 8) & 0xFF),
             static_cast<std::uint8_t>((value.ms >> 16) & 0xFF),
@@ -709,24 +861,24 @@ namespace sdo
 
             static_cast<std::uint8_t>(value.d & 0xFF),
             static_cast<std::uint8_t>((value.d >> 8) & 0xFF)
-        };
+        });
     }
 
     // -Domain-
     // (returns raw blob as equivalent to the EtherCAT Domain data type)
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::vector<std::uint8_t>>(
+    template <> [[nodiscard]] inline SerializeResult serialize<std::vector<std::uint8_t>>(
         const std::vector<std::uint8_t>& value)
     {
-        return value;
+        return SerializeResult::ok(value);
     }
 
     // -Extended Signed Integer-
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int24>(const Int24& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<Int24>(const Int24& value)
     {
         if (value.value < -pow(2, 23) || value.value > pow(2, 23)-1){
-            throw std::out_of_range("Int24 value exceeds 24 bit signed range");
+            SerializeResult::err({ErrorCode::OutOfRange, "Int24 value exceeds 24 bit signed range"});
         }
 
         const auto raw = static_cast<std::uint32_t>(value.value);
@@ -734,10 +886,10 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint32_t>(raw, 3);
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int40>(const Int40& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<Int40>(const Int40& value)
     {
         if (value.value < -pow(2, 39) || value.value > pow(2, 39)-1){
-            throw std::out_of_range("Int40 value exceeds 40 bit signed range");
+            SerializeResult::err({ErrorCode::OutOfRange, "Int40 value exceeds 40 bit signed range"});
         }
 
         const auto raw = static_cast<std::uint64_t>(value.value);
@@ -745,10 +897,10 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint64_t>(raw, 5);
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int48>(const Int48& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<Int48>(const Int48& value)
     {
         if (value.value < -pow(2, 47) || value.value > pow(2, 47)-1){
-            throw std::out_of_range("Int48 value exceeds 48 bit signed range");
+            SerializeResult::err({ErrorCode::OutOfRange, "Int48 value exceeds 48 bit signed range"});
         }
 
         const auto raw = static_cast<std::uint64_t>(value.value);
@@ -756,10 +908,10 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint64_t>(raw, 6);
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int56>(const Int56& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<Int56>(const Int56& value)
     {
         if (value.value < -pow(2, 55) || value.value > pow(2, 55)-1){
-            throw std::out_of_range("Int56 value exceeds 56 bit signed range");
+            SerializeResult::err({ErrorCode::OutOfRange, "Int56 value exceeds 56 bit signed range"});
         }
 
         const auto raw = static_cast<std::uint64_t>(value.value);
@@ -767,58 +919,62 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint64_t>(raw, 7);
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<int64_t>(const int64_t& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<int64_t>(const int64_t& value)
     {
         return sdo::helpers::from_raw<std::uint64_t>(static_cast<std::uint64_t>(value), 8);
     }
 
     // -Extended unsigned Integer-
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt24>(const UInt24& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<UInt24>(const UInt24& value)
     {
         if (value.value > pow(2, 24)-1){
-            throw std::out_of_range("UInt24 value exceeds 24 bit unsigned range");
+            SerializeResult::err({
+                ErrorCode::OutOfRange, "UInt24 value exceeds 24 bit unsigned range"});
         }
 
         return sdo::helpers::from_raw<std::uint32_t>(value.value, 3);
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt40>(const UInt40& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<UInt40>(const UInt40& value)
     {
         if (value.value > pow(2, 40)-1){
-            throw std::out_of_range("UInt40 value exceeds 40 bit unsigned range");
+            SerializeResult::err({
+                ErrorCode::OutOfRange, "UInt40 value exceeds 40 bit unsigned range"});
         }
 
         return sdo::helpers::from_raw<std::uint64_t>(value.value, 5);
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt48>(const UInt48& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<UInt48>(const UInt48& value)
     {
         if (value.value > pow(2, 48)-1){
-            throw std::out_of_range("UInt48 value exceeds 48 bit unsigned range");
+            SerializeResult::err({
+                ErrorCode::OutOfRange, "UInt48 value exceeds 48 bit unsigned range"});
         }
 
         return sdo::helpers::from_raw<std::uint64_t>(value.value, 6);
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt56>(const UInt56& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<UInt56>(const UInt56& value)
     {
         if (value.value > pow(2, 56)-1){
-            throw std::out_of_range("UInt56 value exceeds 56 bit unsigned range");
+            SerializeResult::err({
+                ErrorCode::OutOfRange, "UInt56 value exceeds 56 bit unsigned range"});
         }
 
         return sdo::helpers::from_raw<std::uint64_t>(value.value, 7);
     }
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<uint64_t>(const uint64_t& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<uint64_t>(const uint64_t& value)
     {
         return sdo::helpers::from_raw<std::uint64_t>(value, 8);
     }
 
     // -GUID-
 
-    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Guid>(const Guid& value)
+    template <> [[nodiscard]] inline SerializeResult serialize<Guid>(const Guid& value)
     {
-        return std::vector<std::uint8_t>(value.bytes.begin(), value.bytes.end());
+        return SerializeResult::ok(std::vector<std::uint8_t>(value.bytes.begin(), value.bytes.end()));
     }
 }

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -10,7 +10,7 @@
 #include <cstring>
 #include <cstddef>
 #include <cmath>
-#include "result.hpp"
+#include <rise_motion/result.hpp>
 
 namespace sdo
 {

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <cstring>
 #include <cstddef>
+#include <cmath>
 
 
 namespace sdo::helpers
@@ -267,7 +268,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 3, "Int24");
 
-        std::uint32_t raw = sdo::helpers::to_raw<std::uint16_t>(blob, 3);
+        std::uint32_t raw = sdo::helpers::to_raw<std::uint32_t>(blob, 3);
 
         if (raw & 0x00800000){
             raw |= 0xFF000000;
@@ -488,5 +489,114 @@ namespace sdo
         const std::vector<std::uint8_t>& value)
     {
         return value;
+    }
+
+    // Extended Signed Integer
+
+    template <> inline std::vector<std::uint8_t> serialize<Int24>(const Int24& value)
+    {
+        if (value.value < -pow(2, 23) || value.value > pow(2, 23)-1)
+        {
+            throw std::out_of_range("Int24 value exceeds 24 bit signed range");
+        }
+
+        const auto raw = static_cast<std::uint32_t>(value.value);
+
+        return sdo::helpers::from_raw<std::uint32_t>(raw, 3);
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<Int40>(const Int40& value)
+    {
+        if (value.value < -pow(2, 39) || value.value > pow(2, 39)-1)
+        {
+            throw std::out_of_range("Int40 value exceeds 40 bit signed range");
+        }
+
+        const auto raw = static_cast<std::uint64_t>(value.value);
+
+        return sdo::helpers::from_raw<std::uint64_t>(raw, 5);
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<Int48>(const Int48& value)
+    {
+        if (value.value < -pow(2, 47) || value.value > pow(2, 47)-1)
+        {
+            throw std::out_of_range("Int48 value exceeds 48 bit signed range");
+        }
+
+        const auto raw = static_cast<std::uint64_t>(value.value);
+
+        return sdo::helpers::from_raw<std::uint64_t>(raw, 6);
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<Int56>(const Int56& value)
+    {
+        if (value.value < -pow(2, 55) || value.value > pow(2, 55)-1)
+        {
+            throw std::out_of_range("Int56 value exceeds 56 bit signed range");
+        }
+
+        const auto raw = static_cast<std::uint64_t>(value.value);
+
+        return sdo::helpers::from_raw<std::uint64_t>(raw, 7);
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<int64_t>(const int64_t& value)
+    {
+        return sdo::helpers::from_raw<std::uint64_t>(static_cast<std::uint64_t>(value), 8);
+    }
+
+    // Extended unsigned Integer
+
+    template <> inline std::vector<std::uint8_t> serialize<UInt24>(const UInt24& value)
+    {
+        if (value.value > pow(2, 24)-1)
+        {
+            throw std::out_of_range("UInt24 value exceeds 24 bit unsigned range");
+        }
+
+        return sdo::helpers::from_raw<std::uint32_t>(value.value, 3);
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<UInt40>(const UInt40& value)
+    {
+        if (value.value > pow(2, 40)-1)
+        {
+            throw std::out_of_range("UInt40 value exceeds 40 bit unsigned range");
+        }
+
+        return sdo::helpers::from_raw<std::uint64_t>(value.value, 5);
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<UInt48>(const UInt48& value)
+    {
+        if (value.value > pow(2, 48)-1)
+        {
+            throw std::out_of_range("UInt48 value exceeds 48 bit unsigned range");
+        }
+
+        return sdo::helpers::from_raw<std::uint64_t>(value.value, 6);
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<UInt56>(const UInt56& value)
+    {
+        if (value.value > pow(2, 56)-1)
+        {
+            throw std::out_of_range("UInt56 value exceeds 56 bit unsigned range");
+        }
+
+        return sdo::helpers::from_raw<std::uint64_t>(value.value, 7);
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<uint64_t>(const uint64_t& value)
+    {
+        return sdo::helpers::from_raw<std::uint64_t>(value, 8);
+    }
+
+    // GUID
+
+    template <> inline std::vector<std::uint8_t> serialize<Guid>(const Guid& value)
+    {
+        return std::vector<std::uint8_t>(value.bytes.begin(), value.bytes.end());
     }
 }

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -1045,7 +1045,7 @@ namespace sdo
             if (value.value.size() > size){
                 return SerializeResult::err({
                     ErrorCode::InvalidSize, std::string("serialize<STRING<T>>: string is longer than size T. Expected: ") + 
-                    std::to_string(size) + ", got: " + value.value.size()});
+                    std::to_string(size) + ", got: " + std::to_string(value.value.size())});
             }
 
             std::vector<std::uint8_t> blob(value.value.begin(), value.value.end());

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -1059,7 +1059,7 @@ namespace sdo
 
     template <> [[nodiscard]] inline SerializeResult serialize<bool>(const bool& value)
     {
-        return SerializeResult::ok({static_cast<std::uint8_t>(value ? 1 : 0)});
+        return SerializeResult::ok({static_cast<std::uint8_t>(value ? 0xFF : 0)});
     }
 
     // -Signed Integer-

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -24,7 +24,7 @@ namespace sdo::helpers
         }
     }
 
-    template <typename T> inline T to_raw(
+    template <typename T> [[nodiscard]] inline T to_raw(
         const std::vector<std::uint8_t>& blob, std::size_t numBytes, std::size_t offset = 0)
     {
         static_assert(std::is_unsigned_v<T>, "to_raw<T>: T must be unsigned");
@@ -50,7 +50,7 @@ namespace sdo::helpers
         return raw;
     }
 
-    template <typename T> inline std::vector<std::uint8_t> from_raw(const T& raw, std::size_t numBytes)
+    template <typename T> [[nodiscard]] inline std::vector<std::uint8_t> from_raw(const T& raw, std::size_t numBytes)
     {
         static_assert(std::is_unsigned_v<T>, "from_raw<T>: T must be unsigned");
 
@@ -133,30 +133,32 @@ namespace sdo
     };
 
 
+    // ---DESERIALIZATION---
+
     template <typename T> T deserialize(const std::vector<std::uint8_t>&)
     {
         static_assert(sdo::helpers::always_false<T>, "deserialize<T>: unsupported type");
     }
 
-    // Boolean
+    // -Boolean-
 
-    template <> inline bool deserialize<bool>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline bool deserialize<bool>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 1, "bool");
 
         return blob[0] != 0;
     }
 
-    // Signed Integer
+    // -Signed Integer-
 
-    template <> inline std::int8_t deserialize<std::int8_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline std::int8_t deserialize<std::int8_t>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 1, "int8_t");
 
         return static_cast<std::int8_t>(blob[0]);
     }
 
-    template <> inline std::int16_t deserialize<std::int16_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline std::int16_t deserialize<std::int16_t>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 2, "int16_t");
 
@@ -165,7 +167,7 @@ namespace sdo
         return value;
     }
 
-    template <> inline std::int32_t deserialize<std::int32_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline std::int32_t deserialize<std::int32_t>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 4, "int32_t");
 
@@ -174,10 +176,10 @@ namespace sdo
         return value;
     }
 
-    // Unsigned Integer / raw data / bit arrays / bit strings
+    // -Unsigned Integer / raw data / bit arrays / bit strings-
 
     // use for UNSIGNED8, BYTE, BITARR8, BIT1-BIT8
-    template <> inline std::uint8_t deserialize<std::uint8_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline std::uint8_t deserialize<std::uint8_t>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 1, "uint8_t");
 
@@ -185,7 +187,7 @@ namespace sdo
     }
 
     // use for UNSIGNED16, WORD, BITARR16, BIT9-BIT16
-    template <> inline std::uint16_t deserialize<std::uint16_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline std::uint16_t deserialize<std::uint16_t>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 2, "uint16_t");
 
@@ -193,16 +195,16 @@ namespace sdo
     }
 
     // use for UNSIGNED32, DWORD, BITARR32
-    template <> inline std::uint32_t deserialize<std::uint32_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline std::uint32_t deserialize<std::uint32_t>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 4, "uint32_t");
 
         return sdo::helpers::to_raw<std::uint32_t>(blob, 4);
     }
 
-    // Floating Point
+    // -Floating Point-
 
-    template <> inline float deserialize<float>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline float deserialize<float>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 4, "float");
 
@@ -214,7 +216,7 @@ namespace sdo
         return value;
     }
 
-    template <> inline double deserialize<double>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline double deserialize<double>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 8, "double");
 
@@ -226,9 +228,9 @@ namespace sdo
         return value;
     }
 
-    // Time
+    // -Time-
 
-    template <> inline TimeOfDay deserialize<TimeOfDay>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline TimeOfDay deserialize<TimeOfDay>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 6, "TimeOfDay");
 
@@ -240,7 +242,7 @@ namespace sdo
         return value;
     }
 
-    template <> inline TimeDifference deserialize<TimeDifference>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline TimeDifference deserialize<TimeDifference>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 6, "TimeDifference");
 
@@ -254,17 +256,18 @@ namespace sdo
         return value;
     }
 
-    // Domain (returns raw blob as equivalent to the EtherCAT Domain data type)
+    // -Domain-
+    // (returns raw blob as equivalent to the EtherCAT Domain data type)
 
-    template <> inline std::vector<std::uint8_t> deserialize<std::vector<std::uint8_t>>(
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> deserialize<std::vector<std::uint8_t>>(
         const std::vector<std::uint8_t>& blob)
     {
         return blob;
     }
 
-    // Extended Signed Integer
+    // -Extended Signed Integer-
 
-    template <> inline Int24 deserialize<Int24>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline Int24 deserialize<Int24>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 3, "Int24");
 
@@ -277,7 +280,7 @@ namespace sdo
         return Int24{static_cast<std::int32_t>(raw)};
     }
 
-    template <> inline Int40 deserialize<Int40>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline Int40 deserialize<Int40>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 5, "Int40");
 
@@ -291,7 +294,7 @@ namespace sdo
         return Int40{static_cast<std::int64_t>(raw)};
     }
 
-    template <> inline Int48 deserialize<Int48>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline Int48 deserialize<Int48>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 6, "Int48");
 
@@ -305,7 +308,7 @@ namespace sdo
         return Int48{static_cast<std::int64_t>(raw)};
     }
 
-    template <> inline Int56 deserialize<Int56>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline Int56 deserialize<Int56>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 7, "Int56");
 
@@ -319,53 +322,53 @@ namespace sdo
         return Int56{static_cast<std::int64_t>(raw)};
     }
 
-    template <> inline std::int64_t deserialize<std::int64_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline std::int64_t deserialize<std::int64_t>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 8, "int64_t");
 
         return static_cast<std::int64_t>(sdo::helpers::to_raw<std::uint64_t>(blob, 8));
     }
 
-    // Extended Unsigned Integer
+    // -Extended Unsigned Integer-
 
-    template <> inline UInt24 deserialize<UInt24>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline UInt24 deserialize<UInt24>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 3, "UInt24");
 
         return UInt24{sdo::helpers::to_raw<std::uint32_t>(blob, 3)};
     }
 
-    template <> inline UInt40 deserialize<UInt40>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline UInt40 deserialize<UInt40>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 5, "UInt40");
 
         return UInt40{sdo::helpers::to_raw<std::uint64_t>(blob, 5)};
     }
 
-    template <> inline UInt48 deserialize<UInt48>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline UInt48 deserialize<UInt48>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 6, "UInt48");
 
         return UInt48{sdo::helpers::to_raw<std::uint64_t>(blob, 6)};
     }
 
-    template <> inline UInt56 deserialize<UInt56>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline UInt56 deserialize<UInt56>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 7, "UInt56");
 
         return UInt56{sdo::helpers::to_raw<std::uint64_t>(blob, 7)};
     }
 
-    template <> inline std::uint64_t deserialize<std::uint64_t>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline std::uint64_t deserialize<std::uint64_t>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 8, "uint64_t");
 
         return sdo::helpers::to_raw<std::uint64_t>(blob, 8);
     }
 
-    // GUID
+    // -GUID-
 
-    template <> inline Guid deserialize<Guid>(const std::vector<std::uint8_t>& blob)
+    template <> [[nodiscard]] inline Guid deserialize<Guid>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 16, "Guid");
 
@@ -380,6 +383,7 @@ namespace sdo
     }
 
 
+    // ---SERIALIZATION---
 
     template <typename T> std::vector<std::uint8_t> serialize(const T& value)
     {
@@ -387,54 +391,54 @@ namespace sdo
         return{};
     }
 
-    // Boolean
+    // -Boolean-
 
-    template <> inline std::vector<std::uint8_t> serialize<bool>(const bool& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<bool>(const bool& value)
     {
         return {static_cast<std::uint8_t>(value ? 1 : 0)};
     }
 
-    // Signed Integer
+    // -Signed Integer-
 
-    template <> inline std::vector<std::uint8_t> serialize<std::int8_t>(const std::int8_t& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::int8_t>(const std::int8_t& value)
     {
         return {static_cast<std::uint8_t>(value)};
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<std::int16_t>(const std::int16_t& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::int16_t>(const std::int16_t& value)
     {
         return sdo::helpers::from_raw<std::uint16_t>(static_cast<std::uint16_t>(value), 2);
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<std::int32_t>(const std::int32_t& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::int32_t>(const std::int32_t& value)
     {
         return sdo::helpers::from_raw<std::uint32_t>(static_cast<std::uint32_t>(value), 4);
     }
 
-    // Unsigned Integer / raw data / bit arrays / bit strings
+    // -Unsigned Integer / raw data / bit arrays / bit strings-
 
     // use for UNSIGNED8, BYTE, BITARR8, BIT1-BIT8
-    template <> inline std::vector<std::uint8_t> serialize<std::uint8_t>(const std::uint8_t& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::uint8_t>(const std::uint8_t& value)
     {
         return { value };
     }
 
     // use for UNSIGNED16, WORD, BITARR16, BIT9-BIT16
-    template <> inline std::vector<std::uint8_t> serialize<std::uint16_t>(const std::uint16_t& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::uint16_t>(const std::uint16_t& value)
     {
         return sdo::helpers::from_raw<std::uint16_t>(value, 2);
     }
 
     // use for UNSIGNED32, DWORD, BITARR32
 
-    template <> inline std::vector<std::uint8_t> serialize<std::uint32_t>(const std::uint32_t& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::uint32_t>(const std::uint32_t& value)
     {
         return sdo::helpers::from_raw<std::uint32_t>(value, 4);
     }
 
-    // Floating Point
+    // -Floating Point-
 
-    template <> inline std::vector<std::uint8_t> serialize<float>(const float& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<float>(const float& value)
     {
         std::uint32_t raw;
         std::memcpy(&raw, &value, sizeof(raw));
@@ -442,7 +446,7 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint32_t>(raw, 4);
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<double>(const double& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<double>(const double& value)
     {
         std::uint64_t raw;
         std::memcpy(&raw, &value, sizeof(raw));
@@ -450,9 +454,9 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint64_t>(raw, 8);
     }
 
-    // Time
+    // -Time-
 
-    template <> inline std::vector<std::uint8_t> serialize<TimeOfDay>(const TimeOfDay& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<TimeOfDay>(const TimeOfDay& value)
     {
         return {
             static_cast<std::uint8_t>(value.ms_since_midnight & 0xFF),
@@ -465,7 +469,7 @@ namespace sdo
         };
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<TimeDifference>(const TimeDifference& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<TimeDifference>(const TimeDifference& value)
     {
         if (value.ms > 0x0FFFFFFF)
         {
@@ -483,17 +487,18 @@ namespace sdo
         };
     }
 
-    // Domain (returns raw blob as equivalent to the EtherCAT Domain data type)
+    // -Domain-
+    // (returns raw blob as equivalent to the EtherCAT Domain data type)
 
-    template <> inline std::vector<std::uint8_t> serialize<std::vector<std::uint8_t>>(
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<std::vector<std::uint8_t>>(
         const std::vector<std::uint8_t>& value)
     {
         return value;
     }
 
-    // Extended Signed Integer
+    // -Extended Signed Integer-
 
-    template <> inline std::vector<std::uint8_t> serialize<Int24>(const Int24& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int24>(const Int24& value)
     {
         if (value.value < -pow(2, 23) || value.value > pow(2, 23)-1)
         {
@@ -505,7 +510,7 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint32_t>(raw, 3);
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<Int40>(const Int40& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int40>(const Int40& value)
     {
         if (value.value < -pow(2, 39) || value.value > pow(2, 39)-1)
         {
@@ -517,7 +522,7 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint64_t>(raw, 5);
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<Int48>(const Int48& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int48>(const Int48& value)
     {
         if (value.value < -pow(2, 47) || value.value > pow(2, 47)-1)
         {
@@ -529,7 +534,7 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint64_t>(raw, 6);
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<Int56>(const Int56& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int56>(const Int56& value)
     {
         if (value.value < -pow(2, 55) || value.value > pow(2, 55)-1)
         {
@@ -541,14 +546,14 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint64_t>(raw, 7);
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<int64_t>(const int64_t& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<int64_t>(const int64_t& value)
     {
         return sdo::helpers::from_raw<std::uint64_t>(static_cast<std::uint64_t>(value), 8);
     }
 
-    // Extended unsigned Integer
+    // -Extended unsigned Integer-
 
-    template <> inline std::vector<std::uint8_t> serialize<UInt24>(const UInt24& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt24>(const UInt24& value)
     {
         if (value.value > pow(2, 24)-1)
         {
@@ -558,7 +563,7 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint32_t>(value.value, 3);
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<UInt40>(const UInt40& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt40>(const UInt40& value)
     {
         if (value.value > pow(2, 40)-1)
         {
@@ -568,7 +573,7 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint64_t>(value.value, 5);
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<UInt48>(const UInt48& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt48>(const UInt48& value)
     {
         if (value.value > pow(2, 48)-1)
         {
@@ -578,7 +583,7 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint64_t>(value.value, 6);
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<UInt56>(const UInt56& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt56>(const UInt56& value)
     {
         if (value.value > pow(2, 56)-1)
         {
@@ -588,14 +593,14 @@ namespace sdo
         return sdo::helpers::from_raw<std::uint64_t>(value.value, 7);
     }
 
-    template <> inline std::vector<std::uint8_t> serialize<uint64_t>(const uint64_t& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<uint64_t>(const uint64_t& value)
     {
         return sdo::helpers::from_raw<std::uint64_t>(value, 8);
     }
 
-    // GUID
+    // -GUID-
 
-    template <> inline std::vector<std::uint8_t> serialize<Guid>(const Guid& value)
+    template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Guid>(const Guid& value)
     {
         return std::vector<std::uint8_t>(value.bytes.begin(), value.bytes.end());
     }

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -1,0 +1,418 @@
+// library assumes little-endian
+
+#pragma once
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <array>
+#include <cstring>
+#include <cstddef>
+
+
+namespace sdo::helpers
+{
+    template <typename> inline constexpr bool always_false = false;
+
+    inline void check_size(const std::vector<std::uint8_t>& blob, std::size_t expectedSize, const char* type)
+    {
+        if (blob.size() != expectedSize){
+            throw std::invalid_argument(std::string("deserialize<") + type +
+                ">: expected " + std::to_string(expectedSize) + " bytes, got " + std::to_string(blob.size()));
+        }
+    }
+
+    inline std::uint16_t to_16bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
+    {
+        std::uint16_t raw =
+            static_cast<std::uint16_t>(blob[offset + 0]) |
+            static_cast<std::uint16_t>(blob[offset + 1]) << 8;
+        
+        return raw;
+    }
+
+    inline std::uint32_t to_24bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
+    {
+        std::uint32_t raw =
+            static_cast<std::uint32_t>(blob[offset + 0]) |
+            static_cast<std::uint32_t>(blob[offset + 1]) << 8 |
+            static_cast<std::uint32_t>(blob[offset + 2]) << 16;
+        
+        return raw;
+    }
+
+    inline std::uint32_t to_32bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
+    {
+        std::uint32_t raw =
+            static_cast<std::uint32_t>(blob[offset + 0]) |
+            static_cast<std::uint32_t>(blob[offset + 1]) << 8 |
+            static_cast<std::uint32_t>(blob[offset + 2]) << 16 |
+            static_cast<std::uint32_t>(blob[offset + 3]) << 24;
+        
+        return raw;
+    }
+
+    inline std::uint64_t to_40bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
+    {
+        std::uint64_t raw =
+            static_cast<std::uint64_t>(blob[offset + 0]) |
+            static_cast<std::uint64_t>(blob[offset + 1]) << 8 |
+            static_cast<std::uint64_t>(blob[offset + 2]) << 16 |
+            static_cast<std::uint64_t>(blob[offset + 3]) << 24 |
+            static_cast<std::uint64_t>(blob[offset + 4]) << 32;
+        
+        return raw;
+    }
+
+    inline std::uint64_t to_48bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
+    {
+        std::uint64_t raw =
+            static_cast<std::uint64_t>(blob[offset + 0]) |
+            static_cast<std::uint64_t>(blob[offset + 1]) << 8 |
+            static_cast<std::uint64_t>(blob[offset + 2]) << 16 |
+            static_cast<std::uint64_t>(blob[offset + 3]) << 24 |
+            static_cast<std::uint64_t>(blob[offset + 4]) << 32 |
+            static_cast<std::uint64_t>(blob[offset + 5]) << 40;
+        
+        return raw;
+    }
+
+    inline std::uint64_t to_56bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
+    {
+        std::uint64_t raw =
+            static_cast<std::uint64_t>(blob[offset + 0]) |
+            static_cast<std::uint64_t>(blob[offset + 1]) << 8 |
+            static_cast<std::uint64_t>(blob[offset + 2]) << 16 |
+            static_cast<std::uint64_t>(blob[offset + 3]) << 24 |
+            static_cast<std::uint64_t>(blob[offset + 4]) << 32 |
+            static_cast<std::uint64_t>(blob[offset + 5]) << 40 |
+            static_cast<std::uint64_t>(blob[offset + 6]) << 48;
+        
+        return raw;
+    }
+
+    inline std::uint64_t to_64bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
+    {
+        std::uint64_t raw =
+            static_cast<std::uint64_t>(blob[offset + 0]) |
+            static_cast<std::uint64_t>(blob[offset + 1]) << 8 |
+            static_cast<std::uint64_t>(blob[offset + 2]) << 16 |
+            static_cast<std::uint64_t>(blob[offset + 3]) << 24 |
+            static_cast<std::uint64_t>(blob[offset + 4]) << 32 |
+            static_cast<std::uint64_t>(blob[offset + 5]) << 40 |
+            static_cast<std::uint64_t>(blob[offset + 6]) << 48 |
+            static_cast<std::uint64_t>(blob[offset + 7]) << 56;
+        
+        return raw;
+    }
+}
+
+namespace sdo
+{
+    // as equivalent of the EtherCAT TIME_OF_DAY data type
+    struct TimeOfDay
+    {
+        std::uint32_t ms_since_midnight;
+        std::uint16_t d_since_1984_01_01;
+    };
+
+    // as equivalent of the EtherCAT TIME_DIFFERENCE data type
+    struct TimeDifference
+    {
+        std::uint32_t ms;
+        std::uint16_t d;
+    };
+
+    struct Int24
+    {
+        std::int32_t value;
+    };
+
+    struct Int40
+    {
+        std::int64_t value;
+    };
+
+    struct Int48
+    {
+        std::int64_t value;
+    };
+
+    struct Int56
+    {
+        std::int64_t value;
+    };
+
+    struct UInt24
+    {
+        std::uint32_t value;
+    };
+
+    struct UInt40
+    {
+        std::uint64_t value;
+    };
+
+    struct UInt48
+    {
+        std::uint64_t value;
+    };
+
+    struct UInt56
+    {
+        std::uint64_t value;
+    };
+
+    struct Guid
+    {
+        std::array<std::uint8_t, 16> bytes;
+    };
+
+
+    template <typename T> T deserialize(const std::vector<std::uint8_t>&)
+    {
+        static_assert(sdo::helpers::always_false<T>, "deserialize<T>: unsupported type");
+    }
+
+    // Boolean
+
+    template <> inline bool deserialize<bool>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 1, "bool");
+
+        return blob[0] != 0;
+    }
+
+    // Signed Integer
+
+    template <> inline std::int8_t deserialize<std::int8_t>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 1, "int8_t");
+
+        return static_cast<std::int8_t>(blob[0]);
+    }
+
+    template <> inline std::int16_t deserialize<std::int16_t>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 2, "int16_t");
+
+        std::int16_t value = static_cast<std::int16_t>(sdo::helpers::to_16bit_raw(blob));
+
+        return value;
+    }
+
+    template <> inline std::int32_t deserialize<std::int32_t>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 4, "int32_t");
+
+        std::int32_t value = static_cast<std::int32_t>(sdo::helpers::to_32bit_raw(blob));
+
+        return value;
+    }
+
+    // Unsigned Integer / raw data / bit arrays / bit strings
+
+    // use for UNSIGNED8, BYTE, BITARR8, BIT1-BIT8
+    template <> inline std::uint8_t deserialize<std::uint8_t>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 1, "uint8_t");
+
+        return static_cast<std::uint8_t>(blob[0]);
+    }
+
+    // use for UNSIGNED16, WORD, BITARR16, BIT9-BIT16
+    template <> inline std::uint16_t deserialize<std::uint16_t>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 2, "uint16_t");
+
+        return sdo::helpers::to_16bit_raw(blob);
+    }
+
+    // use for UNSIGNED32, DWORD, BITARR32
+    template <> inline std::uint32_t deserialize<std::uint32_t>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 4, "uint32_t");
+
+        return sdo::helpers::to_32bit_raw(blob);
+    }
+
+    // Floating Point
+
+    template <> inline float deserialize<float>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 4, "float");
+
+        std::uint32_t raw = sdo::helpers::to_32bit_raw(blob);
+
+        float value;
+        std::memcpy(&value, &raw, sizeof(value));
+
+        return value;
+    }
+
+    template <> inline double deserialize<double>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 8, "double");
+
+        std::uint64_t raw = sdo::helpers::to_64bit_raw(blob);
+
+        double value;
+        std::memcpy(&value, &raw, sizeof(value));
+
+        return value;
+    }
+
+    // Time
+
+    template <> inline TimeOfDay deserialize<TimeOfDay>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 6, "TimeOfDay");
+
+        TimeOfDay value{};
+
+        value.ms_since_midnight = sdo::helpers::to_32bit_raw(blob);
+        value.d_since_1984_01_01 = sdo::helpers::to_16bit_raw(blob, 4);
+
+        return value;
+    }
+
+    template <> inline TimeDifference deserialize<TimeDifference>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 6, "TimeDifference");
+
+        TimeDifference value{};
+
+        // the upper 4 bits of ms are reserved
+        value.ms = sdo::helpers::to_32bit_raw(blob) & 0x0FFFFFFF;
+
+        value.d = sdo::helpers::to_16bit_raw(blob, 4);
+
+        return value;
+    }
+
+    // Domain (returns raw blob as equivalent to the EtherCAT Domain data type)
+
+    template <> inline std::vector<std::uint8_t> deserialize<std::vector<std::uint8_t>>(
+        const std::vector<std::uint8_t>& blob)
+    {
+        return blob;
+    }
+
+    // Extended Signed Integer
+
+    template <> inline Int24 deserialize<Int24>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 3, "Int24");
+
+        std::uint32_t raw = sdo::helpers::to_24bit_raw(blob);
+
+        if (raw & 0x00800000){
+            raw |= 0xFF000000;
+        }
+
+        return Int24{static_cast<std::int32_t>(raw)};
+    }
+
+    template <> inline Int40 deserialize<Int40>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 5, "Int40");
+
+        std::uint64_t raw = sdo::helpers::to_40bit_raw(blob);
+
+        if (raw & 0x0000008000000000ULL)
+        {
+            raw |= 0xFFFFFF0000000000ULL;
+        }
+
+        return Int40{static_cast<std::int64_t>(raw)};
+    }
+
+    template <> inline Int48 deserialize<Int48>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 6, "Int48");
+
+        std::uint64_t raw = sdo::helpers::to_48bit_raw(blob);
+
+        if (raw & 0x0000800000000000ULL)
+        {
+            raw |= 0xFFFF000000000000ULL;
+        }
+
+        return Int48{static_cast<std::int64_t>(raw)};
+    }
+
+    template <> inline Int56 deserialize<Int56>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 7, "Int56");
+
+        std::uint64_t raw = sdo::helpers::to_56bit_raw(blob);
+
+        if (raw & 0x0080000000000000ULL)
+        {
+            raw |= 0xFF00000000000000ULL;
+        }
+
+        return Int56{static_cast<std::int64_t>(raw)};
+    }
+
+    template <> inline std::int64_t deserialize<std::int64_t>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 8, "int64_t");
+
+        return static_cast<std::int64_t>(sdo::helpers::to_64bit_raw(blob));
+    }
+
+    // Extended Unsigned Integer
+
+    template <> inline UInt24 deserialize<UInt24>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 3, "UInt24");
+
+        return UInt24{sdo::helpers::to_24bit_raw(blob)};
+    }
+
+    template <> inline UInt40 deserialize<UInt40>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 5, "UInt40");
+
+        return UInt40{sdo::helpers::to_40bit_raw(blob)};
+    }
+
+    template <> inline UInt48 deserialize<UInt48>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 6, "UInt48");
+
+        return UInt48{sdo::helpers::to_48bit_raw(blob)};
+    }
+
+    template <> inline UInt56 deserialize<UInt56>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 7, "UInt56");
+
+        return UInt56{sdo::helpers::to_56bit_raw(blob)};
+    }
+
+    template <> inline std::uint64_t deserialize<std::uint64_t>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 8, "uint64_t");
+
+        return sdo::helpers::to_64bit_raw(blob);
+    }
+
+    // GUID
+
+    template <> inline Guid deserialize<Guid>(const std::vector<std::uint8_t>& blob)
+    {
+        sdo::helpers::check_size(blob, 16, "Guid");
+
+        Guid value{};
+
+        for (std::size_t i = 0; i < value.bytes.size(); ++i)
+        {
+            value.bytes[i] = blob[i];
+        }
+
+        return value;
+    }
+}

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -11,66 +11,6 @@
 #include <cstddef>
 #include <cmath>
 
-
-namespace sdo::helpers
-{
-    template <typename> inline constexpr bool always_false = false;
-
-    inline void check_size(const std::vector<std::uint8_t>& blob, std::size_t expectedSize, const char* type)
-    {
-        if (blob.size() != expectedSize){
-            throw std::invalid_argument(std::string("deserialize<") + type + ">: expected " + 
-                std::to_string(expectedSize) + " bytes, got " + std::to_string(blob.size()));
-        }
-    }
-
-    template <typename T> [[nodiscard]] inline T to_raw(
-        const std::vector<std::uint8_t>& blob, std::size_t numBytes, std::size_t offset = 0)
-    {
-        static_assert(std::is_unsigned_v<T>, "to_raw<T>: T must be unsigned");
-        static_assert(sizeof(T) <= sizeof(std::uint64_t), "to_raw<T>: T can be max uint64_t");
-
-        if (numBytes > sizeof(T))
-        {
-            throw std::invalid_argument("to_raw<T>: numBytes does not fit T");
-        }
-
-        if (offset + numBytes > blob.size())
-        {
-            throw std::out_of_range("to_raw<T>: blob has less bytes than numBytes");
-        }
-
-        T raw = 0;
-
-        for (std::size_t i = 0; i < numBytes; ++i)
-        {
-            raw |= static_cast<T>(blob[offset + i]) << (8 * i);
-        }
-
-        return raw;
-    }
-
-    template <typename T> [[nodiscard]] inline std::vector<std::uint8_t> from_raw(const T& raw, std::size_t numBytes)
-    {
-        static_assert(std::is_unsigned_v<T>, "from_raw<T>: T must be unsigned");
-
-        if (numBytes > sizeof(T))
-        {
-            throw std::invalid_argument("from_raw<T>: numBytes does not fit T");
-        }
-
-        std::vector<std::uint8_t> blob;
-        blob.reserve(numBytes);
-
-        for (std::size_t i = 0; i < numBytes; ++i)
-        {
-            blob.push_back(static_cast<std::uint8_t>((raw >> (8 * i)) & 0xFF));
-        }
-
-        return blob;
-    }
-}
-
 namespace sdo
 {
     // as equivalent of the EtherCAT TIME_OF_DAY data type
@@ -236,6 +176,25 @@ namespace sdo
         }
     };
 
+    template <std::size_t T> struct STRING
+    {
+        std::string value;
+
+        STRING() = default;
+
+        STRING(std::string v) : value(std::move(v))
+        {
+            if (value.size() > T){
+                throw std::out_of_range("STRING<T>: string is too long to be coverted to STRING<T> of size T");
+            }
+        };
+
+        operator std::string() const
+        {
+            return value;
+        }
+    };
+
 
     // IEC 61131-3 data types
     using BOOL  = bool;
@@ -290,13 +249,105 @@ namespace sdo
 
     using GUID   = sdo::Guid;
     using DOMAIN = std::vector<std::uint8_t>;
+}
 
 
+namespace sdo::helpers
+{
+    template <typename> inline constexpr bool always_false = false;
+
+    template <typename T> struct is_string_type : std::false_type {};
+    template <std::size_t T> struct is_string_type<sdo::STRING<T>> : std::true_type {};
+
+    template <typename T> struct string_size;
+    template <std::size_t T> struct string_size<sdo::STRING<T>>
+    {
+        static constexpr std::size_t size = T;
+    };
+
+    inline void check_size(const std::vector<std::uint8_t>& blob, std::size_t expectedSize, const char* type)
+    {
+        if (blob.size() != expectedSize){
+            throw std::invalid_argument(std::string("deserialize<") + type + ">: expected " + 
+                std::to_string(expectedSize) + " bytes, got " + std::to_string(blob.size()));
+        }
+    }
+
+    template <typename T> [[nodiscard]] inline T to_raw(
+        const std::vector<std::uint8_t>& blob, std::size_t numBytes, std::size_t offset = 0)
+    {
+        static_assert(std::is_unsigned_v<T>, "to_raw<T>: T must be unsigned");
+        static_assert(sizeof(T) <= sizeof(std::uint64_t), "to_raw<T>: T can be max uint64_t");
+
+        if (numBytes > sizeof(T))
+        {
+            throw std::invalid_argument("to_raw<T>: numBytes does not fit T");
+        }
+
+        if (offset + numBytes > blob.size())
+        {
+            throw std::out_of_range("to_raw<T>: blob has less bytes than numBytes");
+        }
+
+        T raw = 0;
+
+        for (std::size_t i = 0; i < numBytes; ++i)
+        {
+            raw |= static_cast<T>(blob[offset + i]) << (8 * i);
+        }
+
+        return raw;
+    }
+
+    template <typename T> [[nodiscard]] inline std::vector<std::uint8_t> from_raw(const T& raw, std::size_t numBytes)
+    {
+        static_assert(std::is_unsigned_v<T>, "from_raw<T>: T must be unsigned");
+
+        if (numBytes > sizeof(T))
+        {
+            throw std::invalid_argument("from_raw<T>: numBytes does not fit T");
+        }
+
+        std::vector<std::uint8_t> blob;
+        blob.reserve(numBytes);
+
+        for (std::size_t i = 0; i < numBytes; ++i)
+        {
+            blob.push_back(static_cast<std::uint8_t>((raw >> (8 * i)) & 0xFF));
+        }
+
+        return blob;
+    }
+}
+
+namespace sdo
+{
     // ---DESERIALIZATION---
 
-    template <typename T> T deserialize(const std::vector<std::uint8_t>&)
+    template <typename T> T deserialize(const std::vector<std::uint8_t>& blob)
     {
-        static_assert(sdo::helpers::always_false<T>, "deserialize<T>: unsupported type");
+        if constexpr (sdo::helpers::is_string_type<std::remove_cv_t<std::remove_reference_t<T>>>::value){
+            
+            constexpr std::size_t size = sdo::helpers::string_size<T>::size;
+
+            if (blob.size() > size){
+                throw std::invalid_argument("deserialize<STRING<T>>: blob is larger than the expected size T");
+            }
+
+            T string{};
+
+            string.value.assign(blob.begin(), blob.end());
+
+            // strip padding zeros
+            while (!string.value.empty() && string.value.back() == '\0'){
+                string.value.pop_back();
+            }
+
+            return string;
+        }
+        else{
+            static_assert(sdo::helpers::always_false<T>, "deserialize<T>: unsupported type");
+        }
     }
 
     // -Boolean-
@@ -546,7 +597,22 @@ namespace sdo
 
     template <typename T> std::vector<std::uint8_t> serialize(const T& value)
     {
-        static_assert(sdo::helpers::always_false<T>, "serialize<T>: unsupported type");
+        if constexpr (sdo::helpers::is_string_type<std::remove_cv_t<std::remove_reference_t<T>>>::value){
+
+            constexpr std::size_t size = sdo::helpers::string_size<T>::size;
+
+            if (value.value.size() > size){
+                throw std::out_of_range("serialize<STRING<T>>: string is longer than size T");
+            }
+
+            std::vector<std::uint8_t> blob(value.value.begin(), value.value.end());
+            blob.resize(size, '\0');
+
+            return blob;
+        }
+        else{
+            static_assert(sdo::helpers::always_false<T>, "serialize<T>: unsupported type");
+        }
         return{};
     }
 

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -19,8 +19,8 @@ namespace sdo::helpers
     inline void check_size(const std::vector<std::uint8_t>& blob, std::size_t expectedSize, const char* type)
     {
         if (blob.size() != expectedSize){
-            throw std::invalid_argument(std::string("deserialize<") + type +
-                ">: expected " + std::to_string(expectedSize) + " bytes, got " + std::to_string(blob.size()));
+            throw std::invalid_argument(std::string("deserialize<") + type + ">: expected " + 
+                std::to_string(expectedSize) + " bytes, got " + std::to_string(blob.size()));
         }
     }
 
@@ -90,47 +90,206 @@ namespace sdo
     struct Int24
     {
         std::int32_t value;
+
+        Int24(std::int32_t v) : value(v)
+        {
+            if (v < -pow(2, 23) || v > pow(2, 23)-1){
+                throw std::out_of_range("Can not convert int32_t value exceeding 24 bit signed range into Int24");
+            }
+        }
+
+        operator std::int32_t() const
+        {
+            return value;
+        }
     };
 
     struct Int40
     {
         std::int64_t value;
+
+        Int40(std::int64_t v) : value(v)
+        {
+            if (v < -pow(2, 39) || v > pow(2, 39)-1){
+                throw std::out_of_range("Can not convert int64_t value exceeding 40 bit signed range into Int40");
+            }
+        }
+
+        operator std::int64_t() const
+        {
+            return value;
+        }
     };
 
     struct Int48
     {
         std::int64_t value;
+
+        Int48(std::int64_t v) : value(v)
+        {
+            if (v < -pow(2, 47) || v > pow(2, 47)-1){
+                throw std::out_of_range("Can not convert int64_t value exceeding 48 bit signed range into Int48");
+            }
+        }
+
+        operator std::int64_t() const
+        {
+            return value;
+        }
     };
 
     struct Int56
     {
         std::int64_t value;
+
+        Int56(std::int64_t v) : value(v)
+        {
+            if (v < -pow(2, 55) || v > pow(2, 55)-1){
+                throw std::out_of_range("Can not convert int64_t value exceeding 56 bit signed range into Int56");
+            }
+        }
+
+        operator std::int64_t() const
+        {
+            return value;
+        }
     };
 
     struct UInt24
     {
         std::uint32_t value;
+
+        UInt24(std::uint32_t v) : value(v)
+        {
+            if (v > pow(2, 24)-1){
+                throw std::out_of_range("Can not convert uint32_t value exceeding 24 bit unsigned range into UInt24");
+            }
+        }
+
+        operator std::uint32_t() const
+        {
+            return value;
+        }
     };
 
     struct UInt40
     {
         std::uint64_t value;
+
+        UInt40(std::uint64_t v) : value(v)
+        {
+            if (v > pow(2, 40)-1){
+                throw std::out_of_range("Can not convert uint64_t value exceeding 40 bit unsigned range into UInt40");
+            }
+        }
+
+        operator std::uint64_t() const
+        {
+            return value;
+        }
     };
 
     struct UInt48
     {
         std::uint64_t value;
+
+        UInt48(std::uint64_t v) : value(v)
+        {
+            if (v > pow(2, 48)-1){
+                throw std::out_of_range("Can not convert uint64_t value exceeding 48 bit unsigned range into UInt48");
+            }
+        }
+
+        operator std::uint64_t() const
+        {
+            return value;
+        }
     };
 
     struct UInt56
     {
         std::uint64_t value;
+
+        UInt56(std::uint64_t v) : value(v)
+        {
+            if (v > pow(2, 56)-1){
+                throw std::out_of_range("Can not convert uint64_t value exceeding 56 bit unsigned range into UInt56");
+            }
+        }
+
+        operator std::uint64_t() const
+        {
+            return value;
+        }
     };
 
     struct Guid
     {
         std::array<std::uint8_t, 16> bytes;
+
+        Guid(std::array<std::uint8_t, 16> b) : bytes(b){};
+        Guid() = default;
+
+        operator std::array<std::uint8_t, 16>() const
+        {
+            return bytes;
+        }
     };
+
+
+    // IEC 61131-3 data types
+    using BOOL  = bool;
+
+    using SINT  = std::int8_t;
+    using INT   = std::int16_t;
+    using DINT  = std::int32_t;
+    using LINT  = std::int64_t;
+
+    using USINT = std::uint8_t;
+    using UINT  = std::uint16_t;
+    using UDINT = std::uint32_t;
+    using ULINT = std::uint64_t;
+
+    using REAL  = float;
+    using LREAL = double;
+
+    using BYTE  = std::uint8_t;
+    using WORD  = std::uint16_t;
+    using DWORD = std::uint32_t;
+    using LWORD = std::uint64_t;
+
+    using DATE  = sdo::TimeOfDay;
+    using TIME  = sdo::TimeDifference;
+
+    // EtherCAT data types
+    using BOOLEAN = bool;
+
+    using INTEGER8  = std::int8_t;
+    using INTEGER16 = std::int16_t;
+    using INTEGER24 = sdo::Int24;
+    using INTEGER32 = std::int32_t;
+    using INTEGER40 = sdo::Int40;
+    using INTEGER48 = sdo::Int48;
+    using INTEGER56 = sdo::Int56;
+    using INTEGER64 = std::int64_t;
+
+    using UNSIGNED8  = std::uint8_t;
+    using UNSIGNED16 = std::uint16_t;
+    using UNSIGNED24 = sdo::UInt24;
+    using UNSIGNED32 = std::uint32_t;
+    using UNSIGNED40 = sdo::UInt40;
+    using UNSIGNED48 = sdo::UInt48;
+    using UNSIGNED56 = sdo::UInt56;
+    using UNSIGNED64 = std::uint64_t;
+
+    using REAL32 = float;
+    using REAL64 = double;
+
+    using TIME_OF_DAY     = sdo::TimeOfDay;
+    using TIME_DIFFERENCE = sdo::TimeDifference;
+
+    using GUID   = sdo::Guid;
+    using DOMAIN = std::vector<std::uint8_t>;
 
 
     // ---DESERIALIZATION---
@@ -500,8 +659,7 @@ namespace sdo
 
     template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int24>(const Int24& value)
     {
-        if (value.value < -pow(2, 23) || value.value > pow(2, 23)-1)
-        {
+        if (value.value < -pow(2, 23) || value.value > pow(2, 23)-1){
             throw std::out_of_range("Int24 value exceeds 24 bit signed range");
         }
 
@@ -512,8 +670,7 @@ namespace sdo
 
     template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int40>(const Int40& value)
     {
-        if (value.value < -pow(2, 39) || value.value > pow(2, 39)-1)
-        {
+        if (value.value < -pow(2, 39) || value.value > pow(2, 39)-1){
             throw std::out_of_range("Int40 value exceeds 40 bit signed range");
         }
 
@@ -524,8 +681,7 @@ namespace sdo
 
     template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int48>(const Int48& value)
     {
-        if (value.value < -pow(2, 47) || value.value > pow(2, 47)-1)
-        {
+        if (value.value < -pow(2, 47) || value.value > pow(2, 47)-1){
             throw std::out_of_range("Int48 value exceeds 48 bit signed range");
         }
 
@@ -536,8 +692,7 @@ namespace sdo
 
     template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<Int56>(const Int56& value)
     {
-        if (value.value < -pow(2, 55) || value.value > pow(2, 55)-1)
-        {
+        if (value.value < -pow(2, 55) || value.value > pow(2, 55)-1){
             throw std::out_of_range("Int56 value exceeds 56 bit signed range");
         }
 
@@ -555,8 +710,7 @@ namespace sdo
 
     template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt24>(const UInt24& value)
     {
-        if (value.value > pow(2, 24)-1)
-        {
+        if (value.value > pow(2, 24)-1){
             throw std::out_of_range("UInt24 value exceeds 24 bit unsigned range");
         }
 
@@ -565,8 +719,7 @@ namespace sdo
 
     template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt40>(const UInt40& value)
     {
-        if (value.value > pow(2, 40)-1)
-        {
+        if (value.value > pow(2, 40)-1){
             throw std::out_of_range("UInt40 value exceeds 40 bit unsigned range");
         }
 
@@ -575,8 +728,7 @@ namespace sdo
 
     template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt48>(const UInt48& value)
     {
-        if (value.value > pow(2, 48)-1)
-        {
+        if (value.value > pow(2, 48)-1){
             throw std::out_of_range("UInt48 value exceeds 48 bit unsigned range");
         }
 
@@ -585,8 +737,7 @@ namespace sdo
 
     template <> [[nodiscard]] inline std::vector<std::uint8_t> serialize<UInt56>(const UInt56& value)
     {
-        if (value.value > pow(2, 56)-1)
-        {
+        if (value.value > pow(2, 56)-1){
             throw std::out_of_range("UInt56 value exceeds 56 bit unsigned range");
         }
 

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -415,4 +415,26 @@ namespace sdo
 
         return value;
     }
+
+
+
+    template <typename T> std::vector<std::uint8_t> serialize(const T& value)
+    {
+        static_assert(sdo::helpers::always_false<T>, "serialize<T>: unsupported type");
+        return{};
+    }
+
+    // Boolean
+
+    template <> inline std::vector<std::uint8_t> serialize<bool>(const bool& value)
+    {
+        return {static_cast<std::uint8_t>(value ? 1 : 0)};
+    }
+
+    // Signed Integer
+
+    template <> inline std::vector<std::uint8_t> serialize<std::int8_t>(const std::int8_t& value)
+    {
+        return {static_cast<std::uint8_t>(value)};
+    }
 }

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -308,7 +308,7 @@ namespace sdo
 
     template <std::size_t T> using VISIBLE_STRING = STRING<T>;
     template <std::size_t T> using UNICODE_STRING = WSTRING<T>;
-    template <std::size_t N> using OKTET_STRING = ARRAY<std::uint8_t, N>;
+    template <std::size_t N> using OCTET_STRING = ARRAY<std::uint8_t, N>;
     template <std::size_t N> using ARRAY_OF_USINT = ARRAY<std::uint8_t, N>;
     template <std::size_t N> using ARRAY_OF_UINT = ARRAY<std::uint16_t, N>;
     template <std::size_t N> using ARRAY_OF_INT = ARRAY<std::int16_t, N>;

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -106,6 +106,39 @@ namespace sdo::helpers
         
         return raw;
     }
+
+
+    inline std::vector<std::uint8_t> from_16bit_raw(const std::uint16_t& raw)
+    {
+        return {
+            static_cast<std::uint8_t>(raw & 0xFF),
+            static_cast<std::uint8_t>((raw >> 8) & 0xFF)
+        };
+    }
+
+    inline std::vector<std::uint8_t> from_32bit_raw(const std::uint32_t& raw)
+    {
+        return {
+            static_cast<std::uint8_t>(raw & 0xFF),
+            static_cast<std::uint8_t>((raw >> 8) & 0xFF),
+            static_cast<std::uint8_t>((raw >> 16) & 0xFF),
+            static_cast<std::uint8_t>((raw >> 24) & 0xFF)
+        };
+    }
+
+    inline std::vector<std::uint8_t> from_64bit_raw(const std::uint64_t& raw)
+    {
+        return {
+            static_cast<std::uint8_t>(raw & 0xFF),
+            static_cast<std::uint8_t>((raw >> 8) & 0xFF),
+            static_cast<std::uint8_t>((raw >> 16) & 0xFF),
+            static_cast<std::uint8_t>((raw >> 24) & 0xFF),
+            static_cast<std::uint8_t>((raw >> 32) & 0xFF),
+            static_cast<std::uint8_t>((raw >> 40) & 0xFF),
+            static_cast<std::uint8_t>((raw >> 48) & 0xFF),
+            static_cast<std::uint8_t>((raw >> 56) & 0xFF)
+        };
+    }
 }
 
 namespace sdo
@@ -436,5 +469,95 @@ namespace sdo
     template <> inline std::vector<std::uint8_t> serialize<std::int8_t>(const std::int8_t& value)
     {
         return {static_cast<std::uint8_t>(value)};
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<std::int16_t>(const std::int16_t& value)
+    {
+        return sdo::helpers::from_16bit_raw(static_cast<std::uint16_t>(value));
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<std::int32_t>(const std::int32_t& value)
+    {
+        return sdo::helpers::from_32bit_raw(static_cast<std::uint32_t>(value));
+    }
+
+    // Unsigned Integer / raw data / bit arrays / bit strings
+
+    // use for UNSIGNED8, BYTE, BITARR8, BIT1-BIT8
+    template <> inline std::vector<std::uint8_t> serialize<std::uint8_t>(const std::uint8_t& value)
+    {
+        return { value };
+    }
+
+    // use for UNSIGNED16, WORD, BITARR16, BIT9-BIT16
+    template <> inline std::vector<std::uint8_t> serialize<std::uint16_t>(const std::uint16_t& value)
+    {
+        return sdo::helpers::from_16bit_raw(value);
+    }
+
+    // use for UNSIGNED32, DWORD, BITARR32
+
+    template <> inline std::vector<std::uint8_t> serialize<std::uint32_t>(const std::uint32_t& value)
+    {
+        return sdo::helpers::from_32bit_raw(value);
+    }
+
+    // Floating Point
+
+    template <> inline std::vector<std::uint8_t> serialize<float>(const float& value)
+    {
+        std::uint32_t raw;
+        std::memcpy(&raw, &value, sizeof(raw));
+
+        return sdo::helpers::from_32bit_raw(raw);
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<double>(const double& value)
+    {
+        std::uint64_t raw;
+        std::memcpy(&raw, &value, sizeof(raw));
+
+        return sdo::helpers::from_64bit_raw(raw);
+    }
+
+    // Time
+
+    template <> inline std::vector<std::uint8_t> serialize<TimeOfDay>(const TimeOfDay& value)
+    {
+        return {
+            static_cast<std::uint8_t>(value.ms_since_midnight & 0xFF),
+            static_cast<std::uint8_t>((value.ms_since_midnight >> 8) & 0xFF),
+            static_cast<std::uint8_t>((value.ms_since_midnight >> 16) & 0xFF),
+            static_cast<std::uint8_t>((value.ms_since_midnight >> 24) & 0xFF),
+
+            static_cast<std::uint8_t>(value.d_since_1984_01_01 & 0xFF),
+            static_cast<std::uint8_t>((value.d_since_1984_01_01 >> 8) & 0xFF)
+        };
+    }
+
+    template <> inline std::vector<std::uint8_t> serialize<TimeDifference>(const TimeDifference& value)
+    {
+        if (value.ms > 0x0FFFFFFF)
+        {
+            throw std::out_of_range("serialize<TimeDifference>: TimeDifference.ms exceeds 28 bit range");
+        }
+
+        return {
+            static_cast<std::uint8_t>(value.ms & 0xFF),
+            static_cast<std::uint8_t>((value.ms >> 8) & 0xFF),
+            static_cast<std::uint8_t>((value.ms >> 16) & 0xFF),
+            static_cast<std::uint8_t>((value.ms >> 24) & 0xFF),
+
+            static_cast<std::uint8_t>(value.d & 0xFF),
+            static_cast<std::uint8_t>((value.d >> 8) & 0xFF)
+        };
+    }
+
+    // Domain (returns raw blob as equivalent to the EtherCAT Domain data type)
+
+    template <> inline std::vector<std::uint8_t> serialize<std::vector<std::uint8_t>>(
+        const std::vector<std::uint8_t>& value)
+    {
+        return value;
     }
 }

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -533,7 +533,8 @@ namespace sdo
             if (blob.size() > size){
                 return DeserializeResult<T>::err({
                     ErrorCode::InvalidSize, 
-                    "deserialize<STRING<T>>: blob is larger than the expected size T"});
+                    std::string("deserialize<STRING<T>>: blob is larger than the expected size T. Expected: ") + 
+                    std::to_string(size) + ", got: " + std::to_string(blob.size())});
             }
 
             T str{};
@@ -1043,7 +1044,8 @@ namespace sdo
 
             if (value.value.size() > size){
                 return SerializeResult::err({
-                    ErrorCode::InvalidSize, "serialize<STRING<T>>: string is longer than size T"});
+                    ErrorCode::InvalidSize, std::string("serialize<STRING<T>>: string is longer than size T. Expected: ") + 
+                    std::to_string(size) + ", got: " + value.value.size()});
             }
 
             std::vector<std::uint8_t> blob(value.value.begin(), value.value.end());

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/sdo_serializer.hpp
@@ -23,121 +23,50 @@ namespace sdo::helpers
         }
     }
 
-    inline std::uint16_t to_16bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
+    template <typename T> inline T to_raw(
+        const std::vector<std::uint8_t>& blob, std::size_t numBytes, std::size_t offset = 0)
     {
-        std::uint16_t raw =
-            static_cast<std::uint16_t>(blob[offset + 0]) |
-            static_cast<std::uint16_t>(blob[offset + 1]) << 8;
-        
+        static_assert(std::is_unsigned_v<T>, "to_raw<T>: T must be unsigned");
+        static_assert(sizeof(T) <= sizeof(std::uint64_t), "to_raw<T>: T can be max uint64_t");
+
+        if (numBytes > sizeof(T))
+        {
+            throw std::invalid_argument("to_raw<T>: numBytes does not fit T");
+        }
+
+        if (offset + numBytes > blob.size())
+        {
+            throw std::out_of_range("to_raw<T>: blob has less bytes than numBytes");
+        }
+
+        T raw = 0;
+
+        for (std::size_t i = 0; i < numBytes; ++i)
+        {
+            raw |= static_cast<T>(blob[offset + i]) << (8 * i);
+        }
+
         return raw;
     }
 
-    inline std::uint32_t to_24bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
+    template <typename T> inline std::vector<std::uint8_t> from_raw(const T& raw, std::size_t numBytes)
     {
-        std::uint32_t raw =
-            static_cast<std::uint32_t>(blob[offset + 0]) |
-            static_cast<std::uint32_t>(blob[offset + 1]) << 8 |
-            static_cast<std::uint32_t>(blob[offset + 2]) << 16;
-        
-        return raw;
-    }
+        static_assert(std::is_unsigned_v<T>, "from_raw<T>: T must be unsigned");
 
-    inline std::uint32_t to_32bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
-    {
-        std::uint32_t raw =
-            static_cast<std::uint32_t>(blob[offset + 0]) |
-            static_cast<std::uint32_t>(blob[offset + 1]) << 8 |
-            static_cast<std::uint32_t>(blob[offset + 2]) << 16 |
-            static_cast<std::uint32_t>(blob[offset + 3]) << 24;
-        
-        return raw;
-    }
+        if (numBytes > sizeof(T))
+        {
+            throw std::invalid_argument("from_raw<T>: numBytes does not fit T");
+        }
 
-    inline std::uint64_t to_40bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
-    {
-        std::uint64_t raw =
-            static_cast<std::uint64_t>(blob[offset + 0]) |
-            static_cast<std::uint64_t>(blob[offset + 1]) << 8 |
-            static_cast<std::uint64_t>(blob[offset + 2]) << 16 |
-            static_cast<std::uint64_t>(blob[offset + 3]) << 24 |
-            static_cast<std::uint64_t>(blob[offset + 4]) << 32;
-        
-        return raw;
-    }
+        std::vector<std::uint8_t> blob;
+        blob.reserve(numBytes);
 
-    inline std::uint64_t to_48bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
-    {
-        std::uint64_t raw =
-            static_cast<std::uint64_t>(blob[offset + 0]) |
-            static_cast<std::uint64_t>(blob[offset + 1]) << 8 |
-            static_cast<std::uint64_t>(blob[offset + 2]) << 16 |
-            static_cast<std::uint64_t>(blob[offset + 3]) << 24 |
-            static_cast<std::uint64_t>(blob[offset + 4]) << 32 |
-            static_cast<std::uint64_t>(blob[offset + 5]) << 40;
-        
-        return raw;
-    }
+        for (std::size_t i = 0; i < numBytes; ++i)
+        {
+            blob.push_back(static_cast<std::uint8_t>((raw >> (8 * i)) & 0xFF));
+        }
 
-    inline std::uint64_t to_56bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
-    {
-        std::uint64_t raw =
-            static_cast<std::uint64_t>(blob[offset + 0]) |
-            static_cast<std::uint64_t>(blob[offset + 1]) << 8 |
-            static_cast<std::uint64_t>(blob[offset + 2]) << 16 |
-            static_cast<std::uint64_t>(blob[offset + 3]) << 24 |
-            static_cast<std::uint64_t>(blob[offset + 4]) << 32 |
-            static_cast<std::uint64_t>(blob[offset + 5]) << 40 |
-            static_cast<std::uint64_t>(blob[offset + 6]) << 48;
-        
-        return raw;
-    }
-
-    inline std::uint64_t to_64bit_raw(const std::vector<std::uint8_t>& blob, std::size_t offset = 0)
-    {
-        std::uint64_t raw =
-            static_cast<std::uint64_t>(blob[offset + 0]) |
-            static_cast<std::uint64_t>(blob[offset + 1]) << 8 |
-            static_cast<std::uint64_t>(blob[offset + 2]) << 16 |
-            static_cast<std::uint64_t>(blob[offset + 3]) << 24 |
-            static_cast<std::uint64_t>(blob[offset + 4]) << 32 |
-            static_cast<std::uint64_t>(blob[offset + 5]) << 40 |
-            static_cast<std::uint64_t>(blob[offset + 6]) << 48 |
-            static_cast<std::uint64_t>(blob[offset + 7]) << 56;
-        
-        return raw;
-    }
-
-
-    inline std::vector<std::uint8_t> from_16bit_raw(const std::uint16_t& raw)
-    {
-        return {
-            static_cast<std::uint8_t>(raw & 0xFF),
-            static_cast<std::uint8_t>((raw >> 8) & 0xFF)
-        };
-    }
-
-    inline std::vector<std::uint8_t> from_32bit_raw(const std::uint32_t& raw)
-    {
-        return {
-            static_cast<std::uint8_t>(raw & 0xFF),
-            static_cast<std::uint8_t>((raw >> 8) & 0xFF),
-            static_cast<std::uint8_t>((raw >> 16) & 0xFF),
-            static_cast<std::uint8_t>((raw >> 24) & 0xFF)
-        };
-    }
-
-    inline std::vector<std::uint8_t> from_64bit_raw(const std::uint64_t& raw)
-    {
-        return {
-            static_cast<std::uint8_t>(raw & 0xFF),
-            static_cast<std::uint8_t>((raw >> 8) & 0xFF),
-            static_cast<std::uint8_t>((raw >> 16) & 0xFF),
-            static_cast<std::uint8_t>((raw >> 24) & 0xFF),
-            static_cast<std::uint8_t>((raw >> 32) & 0xFF),
-            static_cast<std::uint8_t>((raw >> 40) & 0xFF),
-            static_cast<std::uint8_t>((raw >> 48) & 0xFF),
-            static_cast<std::uint8_t>((raw >> 56) & 0xFF)
-        };
+        return blob;
     }
 }
 
@@ -230,7 +159,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 2, "int16_t");
 
-        std::int16_t value = static_cast<std::int16_t>(sdo::helpers::to_16bit_raw(blob));
+        std::int16_t value = static_cast<std::int16_t>(sdo::helpers::to_raw<std::uint16_t>(blob, 2));
 
         return value;
     }
@@ -239,7 +168,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 4, "int32_t");
 
-        std::int32_t value = static_cast<std::int32_t>(sdo::helpers::to_32bit_raw(blob));
+        std::int32_t value = static_cast<std::int32_t>(sdo::helpers::to_raw<std::uint32_t>(blob, 4));
 
         return value;
     }
@@ -259,7 +188,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 2, "uint16_t");
 
-        return sdo::helpers::to_16bit_raw(blob);
+        return sdo::helpers::to_raw<std::uint16_t>(blob, 2);
     }
 
     // use for UNSIGNED32, DWORD, BITARR32
@@ -267,7 +196,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 4, "uint32_t");
 
-        return sdo::helpers::to_32bit_raw(blob);
+        return sdo::helpers::to_raw<std::uint32_t>(blob, 4);
     }
 
     // Floating Point
@@ -276,7 +205,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 4, "float");
 
-        std::uint32_t raw = sdo::helpers::to_32bit_raw(blob);
+        std::uint32_t raw = sdo::helpers::to_raw<std::uint32_t>(blob, 4);
 
         float value;
         std::memcpy(&value, &raw, sizeof(value));
@@ -288,7 +217,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 8, "double");
 
-        std::uint64_t raw = sdo::helpers::to_64bit_raw(blob);
+        std::uint64_t raw = sdo::helpers::to_raw<std::uint64_t>(blob, 8);
 
         double value;
         std::memcpy(&value, &raw, sizeof(value));
@@ -304,8 +233,8 @@ namespace sdo
 
         TimeOfDay value{};
 
-        value.ms_since_midnight = sdo::helpers::to_32bit_raw(blob);
-        value.d_since_1984_01_01 = sdo::helpers::to_16bit_raw(blob, 4);
+        value.ms_since_midnight = sdo::helpers::to_raw<std::uint32_t>(blob, 4);
+        value.d_since_1984_01_01 = sdo::helpers::to_raw<std::uint16_t>(blob, 2, 4);
 
         return value;
     }
@@ -317,9 +246,9 @@ namespace sdo
         TimeDifference value{};
 
         // the upper 4 bits of ms are reserved
-        value.ms = sdo::helpers::to_32bit_raw(blob) & 0x0FFFFFFF;
+        value.ms = sdo::helpers::to_raw<std::uint32_t>(blob, 4) & 0x0FFFFFFF;
 
-        value.d = sdo::helpers::to_16bit_raw(blob, 4);
+        value.d = sdo::helpers::to_raw<std::uint16_t>(blob, 2, 4);
 
         return value;
     }
@@ -338,7 +267,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 3, "Int24");
 
-        std::uint32_t raw = sdo::helpers::to_24bit_raw(blob);
+        std::uint32_t raw = sdo::helpers::to_raw<std::uint16_t>(blob, 3);
 
         if (raw & 0x00800000){
             raw |= 0xFF000000;
@@ -351,7 +280,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 5, "Int40");
 
-        std::uint64_t raw = sdo::helpers::to_40bit_raw(blob);
+        std::uint64_t raw = sdo::helpers::to_raw<std::uint64_t>(blob, 5);
 
         if (raw & 0x0000008000000000ULL)
         {
@@ -365,7 +294,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 6, "Int48");
 
-        std::uint64_t raw = sdo::helpers::to_48bit_raw(blob);
+        std::uint64_t raw = sdo::helpers::to_raw<std::uint64_t>(blob, 6);
 
         if (raw & 0x0000800000000000ULL)
         {
@@ -379,7 +308,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 7, "Int56");
 
-        std::uint64_t raw = sdo::helpers::to_56bit_raw(blob);
+        std::uint64_t raw = sdo::helpers::to_raw<std::uint64_t>(blob, 7);
 
         if (raw & 0x0080000000000000ULL)
         {
@@ -393,7 +322,7 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 8, "int64_t");
 
-        return static_cast<std::int64_t>(sdo::helpers::to_64bit_raw(blob));
+        return static_cast<std::int64_t>(sdo::helpers::to_raw<std::uint64_t>(blob, 8));
     }
 
     // Extended Unsigned Integer
@@ -402,35 +331,35 @@ namespace sdo
     {
         sdo::helpers::check_size(blob, 3, "UInt24");
 
-        return UInt24{sdo::helpers::to_24bit_raw(blob)};
+        return UInt24{sdo::helpers::to_raw<std::uint32_t>(blob, 3)};
     }
 
     template <> inline UInt40 deserialize<UInt40>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 5, "UInt40");
 
-        return UInt40{sdo::helpers::to_40bit_raw(blob)};
+        return UInt40{sdo::helpers::to_raw<std::uint64_t>(blob, 5)};
     }
 
     template <> inline UInt48 deserialize<UInt48>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 6, "UInt48");
 
-        return UInt48{sdo::helpers::to_48bit_raw(blob)};
+        return UInt48{sdo::helpers::to_raw<std::uint64_t>(blob, 6)};
     }
 
     template <> inline UInt56 deserialize<UInt56>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 7, "UInt56");
 
-        return UInt56{sdo::helpers::to_56bit_raw(blob)};
+        return UInt56{sdo::helpers::to_raw<std::uint64_t>(blob, 7)};
     }
 
     template <> inline std::uint64_t deserialize<std::uint64_t>(const std::vector<std::uint8_t>& blob)
     {
         sdo::helpers::check_size(blob, 8, "uint64_t");
 
-        return sdo::helpers::to_64bit_raw(blob);
+        return sdo::helpers::to_raw<std::uint64_t>(blob, 8);
     }
 
     // GUID
@@ -473,12 +402,12 @@ namespace sdo
 
     template <> inline std::vector<std::uint8_t> serialize<std::int16_t>(const std::int16_t& value)
     {
-        return sdo::helpers::from_16bit_raw(static_cast<std::uint16_t>(value));
+        return sdo::helpers::from_raw<std::uint16_t>(static_cast<std::uint16_t>(value), 2);
     }
 
     template <> inline std::vector<std::uint8_t> serialize<std::int32_t>(const std::int32_t& value)
     {
-        return sdo::helpers::from_32bit_raw(static_cast<std::uint32_t>(value));
+        return sdo::helpers::from_raw<std::uint32_t>(static_cast<std::uint32_t>(value), 4);
     }
 
     // Unsigned Integer / raw data / bit arrays / bit strings
@@ -492,14 +421,14 @@ namespace sdo
     // use for UNSIGNED16, WORD, BITARR16, BIT9-BIT16
     template <> inline std::vector<std::uint8_t> serialize<std::uint16_t>(const std::uint16_t& value)
     {
-        return sdo::helpers::from_16bit_raw(value);
+        return sdo::helpers::from_raw<std::uint16_t>(value, 2);
     }
 
     // use for UNSIGNED32, DWORD, BITARR32
 
     template <> inline std::vector<std::uint8_t> serialize<std::uint32_t>(const std::uint32_t& value)
     {
-        return sdo::helpers::from_32bit_raw(value);
+        return sdo::helpers::from_raw<std::uint32_t>(value, 4);
     }
 
     // Floating Point
@@ -509,7 +438,7 @@ namespace sdo
         std::uint32_t raw;
         std::memcpy(&raw, &value, sizeof(raw));
 
-        return sdo::helpers::from_32bit_raw(raw);
+        return sdo::helpers::from_raw<std::uint32_t>(raw, 4);
     }
 
     template <> inline std::vector<std::uint8_t> serialize<double>(const double& value)
@@ -517,7 +446,7 @@ namespace sdo
         std::uint64_t raw;
         std::memcpy(&raw, &value, sizeof(raw));
 
-        return sdo::helpers::from_64bit_raw(raw);
+        return sdo::helpers::from_raw<std::uint64_t>(raw, 8);
     }
 
     // Time

--- a/rise_motion_dev_ws/src/rise_motion/src/ec_manager.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/ec_manager.cpp
@@ -309,8 +309,8 @@ uint16 ECManager::transition_ec(uint16 state) {
 }
 
 bool ECManager::sdo_read(uint16 device_id, uint16 index, uint8 subindex,
-                         std::vector<uint8> &value) {
-  int psize = 64;
+                         std::vector<uint8> &value, uint8 value_size) {
+  int psize = value_size;
   uint8 *buf = new uint8[psize];
 
   boolean CA = FALSE;

--- a/rise_motion_dev_ws/src/rise_motion/src/ec_manager.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/ec_manager.cpp
@@ -329,7 +329,7 @@ bool ECManager::sdo_read(uint16 device_id, uint16 index, uint8 subindex,
 bool ECManager::sdo_write(uint16 device_id, uint16 index, uint8 subindex,
                           std::vector<uint8> &value) {
   int psize = value.size();
-  uint8 *buf = new uint8[psize];
+  uint8 *buf = &value[0];
 
   boolean CA = FALSE;
   int wkc = ecx_SDOwrite(&ctx, device_id, index, subindex, CA, psize,

--- a/rise_motion_dev_ws/src/rise_motion/src/ethercat_node.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/ethercat_node.cpp
@@ -118,7 +118,7 @@ void EthercatNode::sdoReadServiceCallback(
 
   std::vector<uint8> value;
   bool success = ec_manager_.sdo_read(request->device_id, request->index,
-				      request->subindex, value);
+				      request->subindex, value, request->value_size);
 
     if (!success) {
     RCLCPP_WARN(get_logger(), "Read failed");

--- a/rise_motion_dev_ws/src/rise_motion/src/ethercat_node.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/ethercat_node.cpp
@@ -131,7 +131,7 @@ void EthercatNode::sdoReadServiceCallback(
   response->index	= request->index;
   response->subindex	= request->subindex;
   response->value	= value;
-  response->value_type	= 0;
+  response->value_type = request->value_type;
 }
 void EthercatNode::sdoWriteServiceCallback(
     const std::shared_ptr<rise_motion_messages::srv::SDOWriteSrv::Request>
@@ -156,5 +156,5 @@ void EthercatNode::sdoWriteServiceCallback(
   response->device_id	= request->device_id;
   response->index	= request->index;
   response->subindex	= request->subindex;
-  response->value_type	= 0;
+  response->value_type = request->value_type;
 }

--- a/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
@@ -78,7 +78,7 @@ public:
   }
 
   template <typename T> auto sdo_read(
-    uint16_t device_id, uint16_t index, uint8_t subindex, uint8_t value_type = 0)
+    uint16_t device_id, uint16_t index, uint8_t subindex, uint8_t value_size, uint8_t value_type = 0)
   {
     auto client = this->create_client<rise_motion_messages::srv::SDOReadSrv>("sdo_read");
 
@@ -94,6 +94,7 @@ public:
     request->device_id = device_id;
     request->index = index;
     request->subindex = subindex;
+    request->value_size = value_size;
     request->value_type = value_type;
 
     auto future = client->async_send_request(request);
@@ -188,8 +189,8 @@ int main(int argc, char **argv) {
   while (!node->request_enable_ethercat()) {
   }
   
-  auto result = node->sdo_read<sdo::STRING<50>>(1, 0x1008, 0, 0);
-
+  // example sdo read
+  auto result = node->sdo_read<sdo::STRING<50>>(1, 0x1008, 0, 0, 50);
   if(!result){
     RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), result.error.message.std::string::c_str());
   }

--- a/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
@@ -9,6 +9,7 @@
 #include <rise_motion_messages/msg/motor_positions.hpp>
 #include <rise_motion_messages/srv/enable_ethercat_srv.hpp>
 #include <rise_motion_messages/srv/sdo_read_srv.hpp>
+#include <rise_motion_messages/srv/sdo_write_srv.hpp>
 #include <rise_motion/sdo_serializer.hpp>
 
 
@@ -106,6 +107,44 @@ public:
 
     return sdo::deserialize<T>(future.get()->value);
   }
+
+  template <typename T>auto sdo_write(
+    uint16_t device_id, uint16_t index, uint8_t subindex, const T &value, uint8_t value_type = 0)
+{
+  auto serialized = sdo::serialize<T>(value);
+
+  if (!serialized){
+    return rise::Result<bool, sdo::Error>::err(serialized.error);
+  }
+
+  auto client = this->create_client<rise_motion_messages::srv::SDOWriteSrv>("sdo_write");
+
+  while (!client->wait_for_service(std::chrono::seconds(1))){
+    if (!rclcpp::ok()){
+      return rise::Result<bool, sdo::Error>::err({
+          sdo::ErrorCode::ServiceUnavailable, "Interrupted while waiting for sdo_write service"});
+    }
+  }
+
+  auto request = std::make_shared<rise_motion_messages::srv::SDOWriteSrv::Request>();
+
+  request->device_id = device_id;
+  request->index = index;
+  request->subindex = subindex;
+  request->value_type = value_type;
+  request->value = serialized.value;
+
+  auto future = client->async_send_request(request);
+
+  if (rclcpp::spin_until_future_complete(this->get_node_base_interface(), future) != rclcpp::FutureReturnCode::SUCCESS){
+    client->remove_pending_request(future);
+
+    return rise::Result<bool, sdo::Error>::err({
+        sdo::ErrorCode::CallFailed, "Failed to call sdo_write service"});
+  }
+
+  return rise::Result<bool, sdo::Error>::ok(true);
+}
 
 
 private:

--- a/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
@@ -76,6 +76,35 @@ public:
     return result->status_enable;
   }
 
+  template <typename T> auto sdo_read(
+    uint16_t device_id, uint16_t index, uint8_t subindex, uint8_t value_type = 0)
+  {
+    auto client = this->create_client<rise_motion_messages::srv::SDOReadSrv>("sdo_read");
+
+    while (!client->wait_for_service(std::chrono::seconds(1))) {
+      if (!rclcpp::ok()) {
+        return sdo::Result<T, std::string>::err({"Interrupted while waiting for sdo_read service"});
+      }
+    }
+
+    auto request = std::make_shared<rise_motion_messages::srv::SDOReadSrv::Request>();
+
+    request->device_id = device_id;
+    request->index = index;
+    request->subindex = subindex;
+    request->value_type = value_type;
+
+    auto future = client->async_send_request(request);
+
+    if (rclcpp::spin_until_future_complete(this, future) != rclcpp::FutureReturnCode::SUCCESS){
+      client->remove_pending_request(future);
+      return sdo::Result<T, std::string>::err({"Failed to call sdo_read service"});
+    }
+
+    return sdo::deserialize<T>(future.get()->value);
+  }
+
+
 private:
   std::vector<int> motor_pos;
   void print_motor_positions(std::vector<int32_t> const &motor_pos,
@@ -117,24 +146,15 @@ int main(int argc, char **argv) {
   while (!node->request_enable_ethercat()) {
   }
   
-  rclcpp::Client<rise_motion_messages::srv::SDOReadSrv>::SharedPtr
-      sdo_client;
-  sdo_client = node->create_client<rise_motion_messages::srv::SDOReadSrv>(
-      "sdo_read");
-  auto request = std::make_shared<rise_motion_messages::srv::SDOReadSrv::Request>();
-  request->device_id = 1;
-  request->index = 0x1008;
-  request->subindex = 0;
-  request->value_type = 0;
-  auto result = sdo_client->async_send_request(request);
-  // wait for result
-  if (rclcpp::spin_until_future_complete(node, result) ==
-    rclcpp::FutureReturnCode::SUCCESS)
-  {
-    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "sdo_value: %s", (std::string(sdo::deserialize<sdo::STRING<50>>(result.get()->value))).std::string::c_str());
-  } else {
-    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Failed to call service sdo_read");
+  auto result = node->sdo_read<sdo::STRING<50>>(1, 0x1008, 0, 0);
+
+  if(!result){
+    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), result.error);
   }
+  else{
+    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "sdo_value: %s", (std::string(result.value.std::string::c_str())));
+  }
+
   rclcpp::spin(node);
   rclcpp::shutdown();
   return 0;

--- a/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
@@ -83,7 +83,8 @@ public:
 
     while (!client->wait_for_service(std::chrono::seconds(1))) {
       if (!rclcpp::ok()) {
-        return sdo::Result<T, std::string>::err({"Interrupted while waiting for sdo_read service"});
+        return rise::Result<T, sdo::Error>::err({
+          sdo::ErrorCode::ServiceUnavailable, "Interrupted while waiting for sdo_read service"});
       }
     }
 
@@ -96,9 +97,11 @@ public:
 
     auto future = client->async_send_request(request);
 
-    if (rclcpp::spin_until_future_complete(this, future) != rclcpp::FutureReturnCode::SUCCESS){
+    if (rclcpp::spin_until_future_complete(
+      this->get_node_base_interface(), future) != rclcpp::FutureReturnCode::SUCCESS){
       client->remove_pending_request(future);
-      return sdo::Result<T, std::string>::err({"Failed to call sdo_read service"});
+      return rise::Result<T, sdo::Error>::err({
+        sdo::ErrorCode::CallFailed, "Failed to call sdo_read service"});
     }
 
     return sdo::deserialize<T>(future.get()->value);
@@ -149,10 +152,10 @@ int main(int argc, char **argv) {
   auto result = node->sdo_read<sdo::STRING<50>>(1, 0x1008, 0, 0);
 
   if(!result){
-    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), result.error);
+    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), result.error.message.std::string::c_str());
   }
   else{
-    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "sdo_value: %s", (std::string(result.value.std::string::c_str())));
+    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "sdo_value: %s", (std::string(result.value).std::string::c_str()));
   }
 
   rclcpp::spin(node);

--- a/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
@@ -189,8 +189,12 @@ int main(int argc, char **argv) {
   while (!node->request_enable_ethercat()) {
   }
   
+  // TODO: solve this inside the ec_manager instead of relying on the user adding this delay
+  // important to prevent potential errors in ec_manager when sending an SDO requests while PDOs and SDOs are not fully initialized yet
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  
   // example sdo read
-  auto result = node->sdo_read<sdo::STRING<50>>(1, 0x1008, 0, 0, 50);
+  auto result = node->sdo_read<sdo::STRING<50>>(1, 0x1008, 0, 50);
   if(!result){
     RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), result.error.message.std::string::c_str());
   }

--- a/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/testing_node.cpp
@@ -2,11 +2,14 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <memory>
 #include <rclcpp/client.hpp>
 #include <rclcpp/logging.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rise_motion_messages/msg/motor_positions.hpp>
 #include <rise_motion_messages/srv/enable_ethercat_srv.hpp>
+#include <rise_motion_messages/srv/sdo_read_srv.hpp>
+#include <rise_motion/sdo_serializer.hpp>
 
 
 class TestNode : public rclcpp::Node {
@@ -112,6 +115,25 @@ int main(int argc, char **argv) {
   auto node = std::make_shared<TestNode>(incs);
 
   while (!node->request_enable_ethercat()) {
+  }
+  
+  rclcpp::Client<rise_motion_messages::srv::SDOReadSrv>::SharedPtr
+      sdo_client;
+  sdo_client = node->create_client<rise_motion_messages::srv::SDOReadSrv>(
+      "sdo_read");
+  auto request = std::make_shared<rise_motion_messages::srv::SDOReadSrv::Request>();
+  request->device_id = 1;
+  request->index = 0x1008;
+  request->subindex = 0;
+  request->value_type = 0;
+  auto result = sdo_client->async_send_request(request);
+  // wait for result
+  if (rclcpp::spin_until_future_complete(node, result) ==
+    rclcpp::FutureReturnCode::SUCCESS)
+  {
+    RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "sdo_value: %s", (std::string(sdo::deserialize<sdo::STRING<50>>(result.get()->value))).std::string::c_str());
+  } else {
+    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Failed to call service sdo_read");
   }
   rclcpp::spin(node);
   rclcpp::shutdown();

--- a/rise_motion_dev_ws/src/rise_motion/test/test_sdo_serializer.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/test/test_sdo_serializer.cpp
@@ -6,10 +6,12 @@ TEST(SDOSerializationTest, Bool)
 {
   bool value = true;
 
-  std::vector<std::uint8_t> blob = sdo::serialize<bool>(value);
-  auto result = sdo::deserialize<bool>(blob);
+  auto blob = sdo::serialize<bool>(value);
+  ASSERT_TRUE(blob);
+  auto result = sdo::deserialize<bool>(blob.value);
+  ASSERT_TRUE(result);
 
-  ASSERT_EQ(result, value);
+  ASSERT_EQ(result.value, value);
 }
 
 TEST(SDOSerializationTest, Int8)
@@ -18,17 +20,23 @@ TEST(SDOSerializationTest, Int8)
   std::int8_t value_max = std::numeric_limits<std::int8_t>::max();
   std::int8_t value_min = std::numeric_limits<std::int8_t>::min();
 
-  std::vector<std::uint8_t> blob = sdo::serialize<std::int8_t>(value_zero);
-  auto result_zero = sdo::deserialize<std::int8_t>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<std::int8_t>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<std::int8_t>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<std::int8_t>(value_max);
-  auto result_max = sdo::deserialize<std::int8_t>(blob);
-  ASSERT_EQ(result_max, value_max);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<std::int8_t>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value, value_max);
 
   blob = sdo::serialize<std::int8_t>(value_min);
-  auto result_min = sdo::deserialize<std::int8_t>(blob);
-  ASSERT_EQ(result_min, value_min);
+  ASSERT_TRUE(blob);
+  auto result_min = sdo::deserialize<std::int8_t>(blob.value);
+  ASSERT_TRUE(result_min);
+  ASSERT_EQ(result_min.value, value_min);
 }
 
 TEST(SDOSerializationTest, Int16)
@@ -37,17 +45,23 @@ TEST(SDOSerializationTest, Int16)
   std::int16_t value_max = std::numeric_limits<std::int16_t>::max();
   std::int16_t value_min = std::numeric_limits<std::int16_t>::min();
 
-  std::vector<std::uint8_t> blob = sdo::serialize<std::int16_t>(value_zero);
-  auto result_zero = sdo::deserialize<std::int16_t>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<std::int16_t>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<std::int16_t>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<std::int16_t>(value_max);
-  auto result_max = sdo::deserialize<std::int16_t>(blob);
-  ASSERT_EQ(result_max, value_max);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<std::int16_t>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value, value_max);
 
   blob = sdo::serialize<std::int16_t>(value_min);
-  auto result_min = sdo::deserialize<std::int16_t>(blob);
-  ASSERT_EQ(result_min, value_min);
+  ASSERT_TRUE(blob);
+  auto result_min = sdo::deserialize<std::int16_t>(blob.value);
+  ASSERT_TRUE(result_min);
+  ASSERT_EQ(result_min.value, value_min);
 }
 
 TEST(SDOSerializationTest, Int32)
@@ -56,17 +70,23 @@ TEST(SDOSerializationTest, Int32)
   std::int32_t value_max = std::numeric_limits<std::int32_t>::max();
   std::int32_t value_min = std::numeric_limits<std::int32_t>::min();
 
-  std::vector<std::uint8_t> blob = sdo::serialize<std::int32_t>(value_zero);
-  auto result_zero = sdo::deserialize<std::int32_t>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<std::int32_t>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<std::int32_t>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<std::int32_t>(value_max);
-  auto result_max = sdo::deserialize<std::int32_t>(blob);
-  ASSERT_EQ(result_max, value_max);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<std::int32_t>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value, value_max);
 
   blob = sdo::serialize<std::int32_t>(value_min);
-  auto result_min = sdo::deserialize<std::int32_t>(blob);
-  ASSERT_EQ(result_min, value_min);
+  ASSERT_TRUE(blob);
+  auto result_min = sdo::deserialize<std::int32_t>(blob.value);
+  ASSERT_TRUE(result_min);
+  ASSERT_EQ(result_min.value, value_min);
 }
 
 TEST(SDOSerializationTest, uInt8)
@@ -74,13 +94,17 @@ TEST(SDOSerializationTest, uInt8)
   std::uint8_t value_zero = 0;
   std::uint8_t value_max = std::numeric_limits<std::uint8_t>::max();
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::USINT>(value_zero);
-  auto result_zero = sdo::deserialize<sdo::UNSIGNED8>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<sdo::USINT>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<sdo::UNSIGNED8>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<std::uint8_t>(value_max);
-  auto result_max = sdo::deserialize<std::uint8_t>(blob);
-  ASSERT_EQ(result_max, value_max);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<std::uint8_t>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value, value_max);
 }
 
 TEST(SDOSerializationTest, uInt16)
@@ -88,13 +112,17 @@ TEST(SDOSerializationTest, uInt16)
   std::uint16_t value_zero = 0;
   std::uint16_t value_max = std::numeric_limits<std::uint16_t>::max();
 
-  std::vector<std::uint8_t> blob = sdo::serialize<std::uint16_t>(value_zero);
-  auto result_zero = sdo::deserialize<std::uint16_t>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<std::uint16_t>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<std::uint16_t>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<std::uint16_t>(value_max);
-  auto result_max = sdo::deserialize<std::uint16_t>(blob);
-  ASSERT_EQ(result_max, value_max);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<std::uint16_t>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value, value_max);
 }
 
 TEST(SDOSerializationTest, uInt32)
@@ -102,13 +130,17 @@ TEST(SDOSerializationTest, uInt32)
   std::uint32_t value_zero = 0;
   std::uint32_t value_max = std::numeric_limits<std::uint32_t>::max();
 
-  std::vector<std::uint8_t> blob = sdo::serialize<std::uint32_t>(value_zero);
-  auto result_zero = sdo::deserialize<std::uint32_t>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<std::uint32_t>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<std::uint32_t>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<std::uint32_t>(value_max);
-  auto result_max = sdo::deserialize<std::uint32_t>(blob);
-  ASSERT_EQ(result_max, value_max);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<std::uint32_t>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value, value_max);
 }
 
 TEST(SDOSerializationTest, Float)
@@ -117,17 +149,23 @@ TEST(SDOSerializationTest, Float)
   float value_pos = 123.456f;
   float value_neg = -123.456f;
 
-  std::vector<std::uint8_t> blob = sdo::serialize<float>(value_zero);
-  auto result_zero = sdo::deserialize<float>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<float>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<float>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<float>(value_pos);
-  auto result_pos = sdo::deserialize<float>(blob);
-  ASSERT_EQ(result_pos, value_pos);
+  ASSERT_TRUE(blob);
+  auto result_pos = sdo::deserialize<float>(blob.value);
+  ASSERT_TRUE(result_pos);
+  ASSERT_EQ(result_pos.value, value_pos);
 
   blob = sdo::serialize<float>(value_neg);
-  auto result_neg = sdo::deserialize<float>(blob);
-  ASSERT_EQ(result_neg, value_neg);
+  ASSERT_TRUE(blob);
+  auto result_neg = sdo::deserialize<float>(blob.value);
+  ASSERT_TRUE(result_neg);
+  ASSERT_EQ(result_neg.value, value_neg);
 }
 
 TEST(SDOSerializationTest, Double)
@@ -136,46 +174,58 @@ TEST(SDOSerializationTest, Double)
   double value_pos = 123.456;
   double value_neg = -123.456;
 
-  std::vector<std::uint8_t> blob = sdo::serialize<double>(value_zero);
-  auto result_zero = sdo::deserialize<double>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<double>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<double>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<double>(value_pos);
-  auto result_pos = sdo::deserialize<double>(blob);
-  ASSERT_EQ(result_pos, value_pos);
+  ASSERT_TRUE(blob);
+  auto result_pos = sdo::deserialize<double>(blob.value);
+  ASSERT_TRUE(result_pos);
+  ASSERT_EQ(result_pos.value, value_pos);
 
   blob = sdo::serialize<double>(value_neg);
-  auto result_neg = sdo::deserialize<double>(blob);
-  ASSERT_EQ(result_neg, value_neg);
+  ASSERT_TRUE(blob);
+  auto result_neg = sdo::deserialize<double>(blob.value);
+  ASSERT_TRUE(result_neg);
+  ASSERT_EQ(result_neg.value, value_neg);
 }
 
 TEST(SDOSerializationTest, TimeOfDay)
 {
   sdo::TimeOfDay value{12345678, 42};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::TimeOfDay>(value);
-  auto result = sdo::deserialize<sdo::TimeOfDay>(blob);
-  ASSERT_EQ(result.ms_since_midnight, value.ms_since_midnight);
-  ASSERT_EQ(result.d_since_1984_01_01, value.d_since_1984_01_01);
+  auto blob = sdo::serialize<sdo::TimeOfDay>(value);
+  ASSERT_TRUE(blob);
+  auto result = sdo::deserialize<sdo::TimeOfDay>(blob.value);
+  ASSERT_TRUE(result);
+  ASSERT_EQ(result.value.ms_since_midnight, value.ms_since_midnight);
+  ASSERT_EQ(result.value.d_since_1984_01_01, value.d_since_1984_01_01);
 }
 
 TEST(SDOSerializationTest, TimeDifference)
 {
   sdo::TimeDifference value{12345678, 42};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::TimeDifference>(value);
-  auto result = sdo::deserialize<sdo::TimeDifference>(blob);
-  ASSERT_EQ(result.ms, value.ms);
-  ASSERT_EQ(result.d, value.d);
+  auto blob = sdo::serialize<sdo::TimeDifference>(value);
+  ASSERT_TRUE(blob);
+  auto result = sdo::deserialize<sdo::TimeDifference>(blob.value);
+  ASSERT_TRUE(result);
+  ASSERT_EQ(result.value.ms, value.ms);
+  ASSERT_EQ(result.value.d, value.d);
 }
 
 TEST(SDOSerializationTest, Domain)
 {
   std::vector<std::uint8_t> value = {0, 1, 2, 3};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<std::vector<std::uint8_t>>(value);
-  auto result = sdo::deserialize<std::vector<std::uint8_t>>(blob);
-  ASSERT_EQ(result, value);
+  auto blob = sdo::serialize<std::vector<std::uint8_t>>(value);
+  ASSERT_TRUE(blob);
+  auto result = sdo::deserialize<std::vector<std::uint8_t>>(blob.value);
+  ASSERT_TRUE(result);
+  ASSERT_EQ(result.value, value);
 }
 
 TEST(SDOSerializationTest, Int24)
@@ -184,17 +234,23 @@ TEST(SDOSerializationTest, Int24)
   sdo::Int24 value_max{(std::int64_t{1} << 23) - 1};
   sdo::Int24 value_min{-(std::int64_t{1} << 23)};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::INTEGER24>(value_zero);
-  auto result_zero = sdo::deserialize<sdo::INTEGER24>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<sdo::INTEGER24>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<sdo::INTEGER24>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<sdo::Int24>(value_max);
-  auto result_max = sdo::deserialize<sdo::Int24>(blob);
-  ASSERT_EQ(result_max.value, value_max.value);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<sdo::Int24>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value.value, value_max.value);
 
   blob = sdo::serialize<sdo::Int24>(value_min);
-  auto result_min = sdo::deserialize<sdo::Int24>(blob);
-  ASSERT_EQ(result_min.value, value_min.value);
+  ASSERT_TRUE(blob);
+  auto result_min = sdo::deserialize<sdo::Int24>(blob.value);
+  ASSERT_TRUE(result_min);
+  ASSERT_EQ(result_min.value.value, value_min.value);
 }
 
 TEST(SDOSerializationTest, Int40)
@@ -203,17 +259,23 @@ TEST(SDOSerializationTest, Int40)
   sdo::Int40 value_max{(std::int64_t{1} << 39) - 1};
   sdo::Int40 value_min{-(std::int64_t{1} << 39)};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::Int40>(value_zero);
-  auto result_zero = sdo::deserialize<sdo::Int40>(blob);
-  ASSERT_EQ(result_zero.value, value_zero.value);
+  auto blob = sdo::serialize<sdo::Int40>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<sdo::Int40>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value.value, value_zero.value);
 
   blob = sdo::serialize<sdo::Int40>(value_max);
-  auto result_max = sdo::deserialize<sdo::Int40>(blob);
-  ASSERT_EQ(result_max.value, value_max.value);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<sdo::Int40>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value.value, value_max.value);
 
   blob = sdo::serialize<sdo::Int40>(value_min);
-  auto result_min = sdo::deserialize<sdo::Int40>(blob);
-  ASSERT_EQ(result_min.value, value_min.value);
+  ASSERT_TRUE(blob);
+  auto result_min = sdo::deserialize<sdo::Int40>(blob.value);
+  ASSERT_TRUE(result_min);
+  ASSERT_EQ(result_min.value.value, value_min.value);
 }
 
 TEST(SDOSerializationTest, Int48)
@@ -222,17 +284,23 @@ TEST(SDOSerializationTest, Int48)
   sdo::Int48 value_max{(std::int64_t{1} << 47) - 1};
   sdo::Int48 value_min{-(std::int64_t{1} << 47)};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::Int48>(value_zero);
-  auto result_zero = sdo::deserialize<sdo::Int48>(blob);
-  ASSERT_EQ(result_zero.value, value_zero.value);
+  auto blob = sdo::serialize<sdo::Int48>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<sdo::Int48>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value.value, value_zero.value);
 
   blob = sdo::serialize<sdo::Int48>(value_max);
-  auto result_max = sdo::deserialize<sdo::Int48>(blob);
-  ASSERT_EQ(result_max.value, value_max.value);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<sdo::Int48>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value.value, value_max.value);
 
   blob = sdo::serialize<sdo::Int48>(value_min);
-  auto result_min = sdo::deserialize<sdo::Int48>(blob);
-  ASSERT_EQ(result_min.value, value_min.value);
+  ASSERT_TRUE(blob);
+  auto result_min = sdo::deserialize<sdo::Int48>(blob.value);
+  ASSERT_TRUE(result_min);
+  ASSERT_EQ(result_min.value.value, value_min.value);
 }
 
 TEST(SDOSerializationTest, Int56)
@@ -241,17 +309,23 @@ TEST(SDOSerializationTest, Int56)
   sdo::Int56 value_max{(std::int64_t{1} << 55) - 1};
   sdo::Int56 value_min{-(std::int64_t{1} << 55)};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::Int56>(value_zero);
-  auto result_zero = sdo::deserialize<sdo::Int56>(blob);
-  ASSERT_EQ(result_zero.value, value_zero.value);
+  auto blob = sdo::serialize<sdo::Int56>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<sdo::Int56>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value.value, value_zero.value);
 
   blob = sdo::serialize<sdo::Int56>(value_max);
-  auto result_max = sdo::deserialize<sdo::Int56>(blob);
-  ASSERT_EQ(result_max.value, value_max.value);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<sdo::Int56>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value.value, value_max.value);
 
   blob = sdo::serialize<sdo::Int56>(value_min);
-  auto result_min = sdo::deserialize<sdo::Int56>(blob);
-  ASSERT_EQ(result_min.value, value_min.value);
+  ASSERT_TRUE(blob);
+  auto result_min = sdo::deserialize<sdo::Int56>(blob.value);
+  ASSERT_TRUE(result_min);
+  ASSERT_EQ(result_min.value.value, value_min.value);
 }
 
 TEST(SDOSerializationTest, Int64)
@@ -260,17 +334,23 @@ TEST(SDOSerializationTest, Int64)
   std::int64_t value_max = std::numeric_limits<std::int64_t>::max();
   std::int64_t value_min = std::numeric_limits<std::int64_t>::min();
 
-  std::vector<std::uint8_t> blob = sdo::serialize<std::int64_t>(value_zero);
-  auto result_zero = sdo::deserialize<std::int64_t>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<std::int64_t>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<std::int64_t>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<std::int64_t>(value_max);
-  auto result_max = sdo::deserialize<std::int64_t>(blob);
-  ASSERT_EQ(result_max, value_max);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<std::int64_t>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value, value_max);
 
   blob = sdo::serialize<std::int64_t>(value_min);
-  auto result_min = sdo::deserialize<std::int64_t>(blob);
-  ASSERT_EQ(result_min, value_min);
+  ASSERT_TRUE(blob);
+  auto result_min = sdo::deserialize<std::int64_t>(blob.value);
+  ASSERT_TRUE(result_min);
+  ASSERT_EQ(result_min.value, value_min);
 }
 
 TEST(SDOSerializationTest, uInt24)
@@ -278,13 +358,17 @@ TEST(SDOSerializationTest, uInt24)
   sdo::UInt24 value_zero{0};
   sdo::UInt24 value_max{(std::uint64_t{1} << 23) - 1};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::UInt24>(value_zero);
-  auto result_zero = sdo::deserialize<sdo::UInt24>(blob);
-  ASSERT_EQ(result_zero.value, value_zero.value);
+  auto blob = sdo::serialize<sdo::UInt24>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<sdo::UInt24>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value.value, value_zero.value);
 
   blob = sdo::serialize<sdo::UInt24>(value_max);
-  auto result_max = sdo::deserialize<sdo::UInt24>(blob);
-  ASSERT_EQ(result_max.value, value_max.value);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<sdo::UInt24>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value.value, value_max.value);
 }
 
 TEST(SDOSerializationTest, uInt40)
@@ -292,13 +376,17 @@ TEST(SDOSerializationTest, uInt40)
   sdo::UInt40 value_zero{0};
   sdo::UInt40 value_max{(std::uint64_t{1} << 40) - 1};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::UInt40>(value_zero);
-  auto result_zero = sdo::deserialize<sdo::UInt40>(blob);
-  ASSERT_EQ(result_zero.value, value_zero.value);
+  auto blob = sdo::serialize<sdo::UInt40>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<sdo::UInt40>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value.value, value_zero.value);
 
   blob = sdo::serialize<sdo::UInt40>(value_max);
-  auto result_max = sdo::deserialize<sdo::UInt40>(blob);
-  ASSERT_EQ(result_max.value, value_max.value);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<sdo::UInt40>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value.value, value_max.value);
 }
 
 TEST(SDOSerializationTest, uInt48)
@@ -306,13 +394,17 @@ TEST(SDOSerializationTest, uInt48)
   sdo::UInt48 value_zero{0};
   sdo::UInt48 value_max{(std::uint64_t{1} << 48) - 1};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::UInt48>(value_zero);
-  auto result_zero = sdo::deserialize<sdo::UInt48>(blob);
-  ASSERT_EQ(result_zero.value, value_zero.value);
+  auto blob = sdo::serialize<sdo::UInt48>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<sdo::UInt48>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value.value, value_zero.value);
 
   blob = sdo::serialize<sdo::UInt48>(value_max);
-  auto result_max = sdo::deserialize<sdo::UInt48>(blob);
-  ASSERT_EQ(result_max.value, value_max.value);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<sdo::UInt48>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value.value, value_max.value);
 }
 
 TEST(SDOSerializationTest, uInt56)
@@ -320,13 +412,17 @@ TEST(SDOSerializationTest, uInt56)
   sdo::UInt56 value_zero{0};
   sdo::UInt56 value_max{(std::uint64_t{1} << 56) - 1};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::UInt56>(value_zero);
-  auto result_zero = sdo::deserialize<sdo::UInt56>(blob);
-  ASSERT_EQ(result_zero.value, value_zero.value);
+  auto blob = sdo::serialize<sdo::UInt56>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<sdo::UInt56>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value.value, value_zero.value);
 
   blob = sdo::serialize<sdo::UInt56>(value_max);
-  auto result_max = sdo::deserialize<sdo::UInt56>(blob);
-  ASSERT_EQ(result_max.value, value_max.value);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<sdo::UInt56>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value.value, value_max.value);
 }
 
 TEST(SDOSerializationTest, uInt64)
@@ -334,13 +430,17 @@ TEST(SDOSerializationTest, uInt64)
   std::uint64_t value_zero = 0;
   std::uint64_t value_max = std::numeric_limits<std::uint64_t>::max();
 
-  std::vector<std::uint8_t> blob = sdo::serialize<std::uint64_t>(value_zero);
-  auto result_zero = sdo::deserialize<std::uint64_t>(blob);
-  ASSERT_EQ(result_zero, value_zero);
+  auto blob = sdo::serialize<std::uint64_t>(value_zero);
+  ASSERT_TRUE(blob);
+  auto result_zero = sdo::deserialize<std::uint64_t>(blob.value);
+  ASSERT_TRUE(result_zero);
+  ASSERT_EQ(result_zero.value, value_zero);
 
   blob = sdo::serialize<std::uint64_t>(value_max);
-  auto result_max = sdo::deserialize<std::uint64_t>(blob);
-  ASSERT_EQ(result_max, value_max);
+  ASSERT_TRUE(blob);
+  auto result_max = sdo::deserialize<std::uint64_t>(blob.value);
+  ASSERT_TRUE(result_max);
+  ASSERT_EQ(result_max.value, value_max);
 }
 
 TEST(SDOSerializationTest, Guid)
@@ -352,30 +452,34 @@ TEST(SDOSerializationTest, Guid)
       13, 14, 15, 16
   }};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::Guid>(value);
-  auto result = sdo::deserialize<sdo::Guid>(blob);
-  ASSERT_EQ(result.bytes, value.bytes);
+  auto blob = sdo::serialize<sdo::Guid>(value);
+  ASSERT_TRUE(blob);
+  auto result = sdo::deserialize<sdo::Guid>(blob.value);
+  ASSERT_TRUE(result);
+  ASSERT_EQ(result.value.bytes, value.bytes);
 }
 
 TEST(SDOSerializationTest, String50)
 {
-  std::string string = "RISE";
+  std::string str = "RISE";
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::STRING<50>>(string);
+  auto blob = sdo::serialize<sdo::STRING<50>>(str);
+  ASSERT_TRUE(blob);
 
-  ASSERT_EQ(blob.size(), 50);
+  ASSERT_EQ(blob.value.size(), 50);
 
-  ASSERT_EQ(blob[0], static_cast<std::uint8_t>('R'));
-  ASSERT_EQ(blob[1], static_cast<std::uint8_t>('I'));
-  ASSERT_EQ(blob[2], static_cast<std::uint8_t>('S'));
-  ASSERT_EQ(blob[3], static_cast<std::uint8_t>('E'));
+  ASSERT_EQ(blob.value[0], static_cast<std::uint8_t>('R'));
+  ASSERT_EQ(blob.value[1], static_cast<std::uint8_t>('I'));
+  ASSERT_EQ(blob.value[2], static_cast<std::uint8_t>('S'));
+  ASSERT_EQ(blob.value[3], static_cast<std::uint8_t>('E'));
 
-  for (std::size_t i = string.size(); i < blob.size(); ++i)
+  for (std::size_t i = str.size(); i < blob.value.size(); ++i)
   {
-    ASSERT_EQ(blob[i], 0);
+    ASSERT_EQ(blob.value[i], 0);
   }
 
-  std::string result = sdo::deserialize<sdo::STRING<50>>(blob);
+  auto result = sdo::deserialize<sdo::STRING<50>>(blob.value);
+  ASSERT_TRUE(result);
 
-  ASSERT_EQ(result, string);
+  ASSERT_EQ(std::string(result.value), str);
 }

--- a/rise_motion_dev_ws/src/rise_motion/test/test_sdo_serializer.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/test/test_sdo_serializer.cpp
@@ -483,3 +483,80 @@ TEST(SDOSerializationTest, String50)
 
   ASSERT_EQ(std::string(result.value), str);
 }
+
+TEST(SDOSerializationTest, WString50)
+{
+  std::u16string str = u"RISE";
+
+  auto blob = sdo::serialize<sdo::WSTRING<50>>(str);
+  ASSERT_TRUE(blob);
+
+  ASSERT_EQ(blob.value.size(), 100);
+
+  ASSERT_EQ(blob.value[0], static_cast<std::uint8_t>('R'));
+  ASSERT_EQ(blob.value[1], 0);
+  ASSERT_EQ(blob.value[2], static_cast<std::uint8_t>('I'));
+  ASSERT_EQ(blob.value[3], 0);
+  ASSERT_EQ(blob.value[4], static_cast<std::uint8_t>('S'));
+  ASSERT_EQ(blob.value[5], 0);
+  ASSERT_EQ(blob.value[6], static_cast<std::uint8_t>('E'));
+  ASSERT_EQ(blob.value[7], 0);
+
+  for (std::size_t i = str.size() * 2; i < blob.value.size(); ++i)
+  {
+    ASSERT_EQ(blob.value[i], 0);
+  }
+
+  auto result = sdo::deserialize<sdo::WSTRING<50>>(blob.value);
+  ASSERT_TRUE(result);
+
+  ASSERT_EQ(std::u16string(result.value), str);
+}
+
+TEST(SDOSerializationTest, ArrayUInt16)
+{
+  sdo::ARRAY_OF_BITARR16<5> value{{1, 2, 3, 4, 5}};
+
+  auto blob = sdo::serialize<sdo::ARRAY_OF_BITARR16<5>>(value);
+  ASSERT_TRUE(blob);
+
+  ASSERT_EQ(blob.value.size(), 10);
+
+  ASSERT_EQ(blob.value[0], 1);
+  ASSERT_EQ(blob.value[1], 0);
+  ASSERT_EQ(blob.value[2], 2);
+  ASSERT_EQ(blob.value[3], 0);
+  ASSERT_EQ(blob.value[4], 3);
+  ASSERT_EQ(blob.value[5], 0);
+  ASSERT_EQ(blob.value[6], 4);
+  ASSERT_EQ(blob.value[7], 0);
+  ASSERT_EQ(blob.value[8], 5);
+  ASSERT_EQ(blob.value[9], 0);
+
+  auto result = sdo::deserialize<sdo::ARRAY_OF_BITARR16<5>>(blob.value);
+  ASSERT_TRUE(result);
+
+  ASSERT_EQ(result.value.value, value.value);
+}
+
+TEST(SDOSerializationTest, ArrayInt16)
+{
+  sdo::ARRAY_OF_INT<3> value{{0, 123, -1}};
+
+  auto blob = sdo::serialize<sdo::ARRAY_OF_INT<3>>(value);
+  ASSERT_TRUE(blob);
+
+  ASSERT_EQ(blob.value.size(), 6);
+
+  ASSERT_EQ(blob.value[0], 0);
+  ASSERT_EQ(blob.value[1], 0);
+  ASSERT_EQ(blob.value[2], 123);
+  ASSERT_EQ(blob.value[3], 0);
+  ASSERT_EQ(blob.value[4], 0xFF);
+  ASSERT_EQ(blob.value[5], 0xFF);
+
+  auto result = sdo::deserialize<sdo::ARRAY_OF_INT<3>>(blob.value);
+  ASSERT_TRUE(result);
+
+  ASSERT_EQ(result.value.value, value.value);
+}

--- a/rise_motion_dev_ws/src/rise_motion/test/test_sdo_serializer.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/test/test_sdo_serializer.cpp
@@ -74,8 +74,8 @@ TEST(SDOSerializationTest, uInt8)
   std::uint8_t value_zero = 0;
   std::uint8_t value_max = std::numeric_limits<std::uint8_t>::max();
 
-  std::vector<std::uint8_t> blob = sdo::serialize<std::uint8_t>(value_zero);
-  auto result_zero = sdo::deserialize<std::uint8_t>(blob);
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::USINT>(value_zero);
+  auto result_zero = sdo::deserialize<sdo::UNSIGNED8>(blob);
   ASSERT_EQ(result_zero, value_zero);
 
   blob = sdo::serialize<std::uint8_t>(value_max);
@@ -180,13 +180,13 @@ TEST(SDOSerializationTest, Domain)
 
 TEST(SDOSerializationTest, Int24)
 {
-  sdo::Int24 value_zero{0};
+  std::int32_t value_zero = 0;
   sdo::Int24 value_max{(std::int64_t{1} << 23) - 1};
   sdo::Int24 value_min{-(std::int64_t{1} << 23)};
 
-  std::vector<std::uint8_t> blob = sdo::serialize<sdo::Int24>(value_zero);
-  auto result_zero = sdo::deserialize<sdo::Int24>(blob);
-  ASSERT_EQ(result_zero.value, value_zero.value);
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::INTEGER24>(value_zero);
+  auto result_zero = sdo::deserialize<sdo::INTEGER24>(blob);
+  ASSERT_EQ(result_zero, value_zero);
 
   blob = sdo::serialize<sdo::Int24>(value_max);
   auto result_max = sdo::deserialize<sdo::Int24>(blob);
@@ -355,4 +355,27 @@ TEST(SDOSerializationTest, Guid)
   std::vector<std::uint8_t> blob = sdo::serialize<sdo::Guid>(value);
   auto result = sdo::deserialize<sdo::Guid>(blob);
   ASSERT_EQ(result.bytes, value.bytes);
+}
+
+TEST(SDOSerializationTest, String50)
+{
+  std::string string = "RISE";
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::STRING<50>>(string);
+
+  ASSERT_EQ(blob.size(), 50);
+
+  ASSERT_EQ(blob[0], static_cast<std::uint8_t>('R'));
+  ASSERT_EQ(blob[1], static_cast<std::uint8_t>('I'));
+  ASSERT_EQ(blob[2], static_cast<std::uint8_t>('S'));
+  ASSERT_EQ(blob[3], static_cast<std::uint8_t>('E'));
+
+  for (std::size_t i = string.size(); i < blob.size(); ++i)
+  {
+    ASSERT_EQ(blob[i], 0);
+  }
+
+  std::string result = sdo::deserialize<sdo::STRING<50>>(blob);
+
+  ASSERT_EQ(result, string);
 }

--- a/rise_motion_dev_ws/src/rise_motion/test/test_sdo_serializer.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/test/test_sdo_serializer.cpp
@@ -15,8 +15,8 @@ TEST(SDOSerializationTest, Bool)
 TEST(SDOSerializationTest, Int8)
 {
   std::int8_t value_zero = 0;
-  std::int8_t value_max = 127;
-  std::int8_t value_min = -128;
+  std::int8_t value_max = std::numeric_limits<std::int8_t>::max();
+  std::int8_t value_min = std::numeric_limits<std::int8_t>::min();
 
   std::vector<std::uint8_t> blob = sdo::serialize<std::int8_t>(value_zero);
   auto result_zero = sdo::deserialize<std::int8_t>(blob);
@@ -29,4 +29,330 @@ TEST(SDOSerializationTest, Int8)
   blob = sdo::serialize<std::int8_t>(value_min);
   auto result_min = sdo::deserialize<std::int8_t>(blob);
   ASSERT_EQ(result_min, value_min);
+}
+
+TEST(SDOSerializationTest, Int16)
+{
+  std::int16_t value_zero = 0;
+  std::int16_t value_max = std::numeric_limits<std::int16_t>::max();
+  std::int16_t value_min = std::numeric_limits<std::int16_t>::min();
+
+  std::vector<std::uint8_t> blob = sdo::serialize<std::int16_t>(value_zero);
+  auto result_zero = sdo::deserialize<std::int16_t>(blob);
+  ASSERT_EQ(result_zero, value_zero);
+
+  blob = sdo::serialize<std::int16_t>(value_max);
+  auto result_max = sdo::deserialize<std::int16_t>(blob);
+  ASSERT_EQ(result_max, value_max);
+
+  blob = sdo::serialize<std::int16_t>(value_min);
+  auto result_min = sdo::deserialize<std::int16_t>(blob);
+  ASSERT_EQ(result_min, value_min);
+}
+
+TEST(SDOSerializationTest, Int32)
+{
+  std::int32_t value_zero = 0;
+  std::int32_t value_max = std::numeric_limits<std::int32_t>::max();
+  std::int32_t value_min = std::numeric_limits<std::int32_t>::min();
+
+  std::vector<std::uint8_t> blob = sdo::serialize<std::int32_t>(value_zero);
+  auto result_zero = sdo::deserialize<std::int32_t>(blob);
+  ASSERT_EQ(result_zero, value_zero);
+
+  blob = sdo::serialize<std::int32_t>(value_max);
+  auto result_max = sdo::deserialize<std::int32_t>(blob);
+  ASSERT_EQ(result_max, value_max);
+
+  blob = sdo::serialize<std::int32_t>(value_min);
+  auto result_min = sdo::deserialize<std::int32_t>(blob);
+  ASSERT_EQ(result_min, value_min);
+}
+
+TEST(SDOSerializationTest, uInt8)
+{
+  std::uint8_t value_zero = 0;
+  std::uint8_t value_max = std::numeric_limits<std::uint8_t>::max();
+
+  std::vector<std::uint8_t> blob = sdo::serialize<std::uint8_t>(value_zero);
+  auto result_zero = sdo::deserialize<std::uint8_t>(blob);
+  ASSERT_EQ(result_zero, value_zero);
+
+  blob = sdo::serialize<std::uint8_t>(value_max);
+  auto result_max = sdo::deserialize<std::uint8_t>(blob);
+  ASSERT_EQ(result_max, value_max);
+}
+
+TEST(SDOSerializationTest, uInt16)
+{
+  std::uint16_t value_zero = 0;
+  std::uint16_t value_max = std::numeric_limits<std::uint16_t>::max();
+
+  std::vector<std::uint8_t> blob = sdo::serialize<std::uint16_t>(value_zero);
+  auto result_zero = sdo::deserialize<std::uint16_t>(blob);
+  ASSERT_EQ(result_zero, value_zero);
+
+  blob = sdo::serialize<std::uint16_t>(value_max);
+  auto result_max = sdo::deserialize<std::uint16_t>(blob);
+  ASSERT_EQ(result_max, value_max);
+}
+
+TEST(SDOSerializationTest, uInt32)
+{
+  std::uint32_t value_zero = 0;
+  std::uint32_t value_max = std::numeric_limits<std::uint32_t>::max();
+
+  std::vector<std::uint8_t> blob = sdo::serialize<std::uint32_t>(value_zero);
+  auto result_zero = sdo::deserialize<std::uint32_t>(blob);
+  ASSERT_EQ(result_zero, value_zero);
+
+  blob = sdo::serialize<std::uint32_t>(value_max);
+  auto result_max = sdo::deserialize<std::uint32_t>(blob);
+  ASSERT_EQ(result_max, value_max);
+}
+
+TEST(SDOSerializationTest, Float)
+{
+  float value_zero = 0.0f;
+  float value_pos = 123.456f;
+  float value_neg = -123.456f;
+
+  std::vector<std::uint8_t> blob = sdo::serialize<float>(value_zero);
+  auto result_zero = sdo::deserialize<float>(blob);
+  ASSERT_EQ(result_zero, value_zero);
+
+  blob = sdo::serialize<float>(value_pos);
+  auto result_pos = sdo::deserialize<float>(blob);
+  ASSERT_EQ(result_pos, value_pos);
+
+  blob = sdo::serialize<float>(value_neg);
+  auto result_neg = sdo::deserialize<float>(blob);
+  ASSERT_EQ(result_neg, value_neg);
+}
+
+TEST(SDOSerializationTest, Double)
+{
+  double value_zero = 0.0;
+  double value_pos = 123.456;
+  double value_neg = -123.456;
+
+  std::vector<std::uint8_t> blob = sdo::serialize<double>(value_zero);
+  auto result_zero = sdo::deserialize<double>(blob);
+  ASSERT_EQ(result_zero, value_zero);
+
+  blob = sdo::serialize<double>(value_pos);
+  auto result_pos = sdo::deserialize<double>(blob);
+  ASSERT_EQ(result_pos, value_pos);
+
+  blob = sdo::serialize<double>(value_neg);
+  auto result_neg = sdo::deserialize<double>(blob);
+  ASSERT_EQ(result_neg, value_neg);
+}
+
+TEST(SDOSerializationTest, TimeOfDay)
+{
+  sdo::TimeOfDay value{12345678, 42};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::TimeOfDay>(value);
+  auto result = sdo::deserialize<sdo::TimeOfDay>(blob);
+  ASSERT_EQ(result.ms_since_midnight, value.ms_since_midnight);
+  ASSERT_EQ(result.d_since_1984_01_01, value.d_since_1984_01_01);
+}
+
+TEST(SDOSerializationTest, TimeDifference)
+{
+  sdo::TimeDifference value{12345678, 42};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::TimeDifference>(value);
+  auto result = sdo::deserialize<sdo::TimeDifference>(blob);
+  ASSERT_EQ(result.ms, value.ms);
+  ASSERT_EQ(result.d, value.d);
+}
+
+TEST(SDOSerializationTest, Domain)
+{
+  std::vector<std::uint8_t> value = {0, 1, 2, 3};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<std::vector<std::uint8_t>>(value);
+  auto result = sdo::deserialize<std::vector<std::uint8_t>>(blob);
+  ASSERT_EQ(result, value);
+}
+
+TEST(SDOSerializationTest, Int24)
+{
+  sdo::Int24 value_zero{0};
+  sdo::Int24 value_max{(std::int64_t{1} << 23) - 1};
+  sdo::Int24 value_min{-(std::int64_t{1} << 23)};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::Int24>(value_zero);
+  auto result_zero = sdo::deserialize<sdo::Int24>(blob);
+  ASSERT_EQ(result_zero.value, value_zero.value);
+
+  blob = sdo::serialize<sdo::Int24>(value_max);
+  auto result_max = sdo::deserialize<sdo::Int24>(blob);
+  ASSERT_EQ(result_max.value, value_max.value);
+
+  blob = sdo::serialize<sdo::Int24>(value_min);
+  auto result_min = sdo::deserialize<sdo::Int24>(blob);
+  ASSERT_EQ(result_min.value, value_min.value);
+}
+
+TEST(SDOSerializationTest, Int40)
+{
+  sdo::Int40 value_zero{0};
+  sdo::Int40 value_max{(std::int64_t{1} << 39) - 1};
+  sdo::Int40 value_min{-(std::int64_t{1} << 39)};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::Int40>(value_zero);
+  auto result_zero = sdo::deserialize<sdo::Int40>(blob);
+  ASSERT_EQ(result_zero.value, value_zero.value);
+
+  blob = sdo::serialize<sdo::Int40>(value_max);
+  auto result_max = sdo::deserialize<sdo::Int40>(blob);
+  ASSERT_EQ(result_max.value, value_max.value);
+
+  blob = sdo::serialize<sdo::Int40>(value_min);
+  auto result_min = sdo::deserialize<sdo::Int40>(blob);
+  ASSERT_EQ(result_min.value, value_min.value);
+}
+
+TEST(SDOSerializationTest, Int48)
+{
+  sdo::Int48 value_zero{0};
+  sdo::Int48 value_max{(std::int64_t{1} << 47) - 1};
+  sdo::Int48 value_min{-(std::int64_t{1} << 47)};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::Int48>(value_zero);
+  auto result_zero = sdo::deserialize<sdo::Int48>(blob);
+  ASSERT_EQ(result_zero.value, value_zero.value);
+
+  blob = sdo::serialize<sdo::Int48>(value_max);
+  auto result_max = sdo::deserialize<sdo::Int48>(blob);
+  ASSERT_EQ(result_max.value, value_max.value);
+
+  blob = sdo::serialize<sdo::Int48>(value_min);
+  auto result_min = sdo::deserialize<sdo::Int48>(blob);
+  ASSERT_EQ(result_min.value, value_min.value);
+}
+
+TEST(SDOSerializationTest, Int56)
+{
+  sdo::Int56 value_zero{0};
+  sdo::Int56 value_max{(std::int64_t{1} << 55) - 1};
+  sdo::Int56 value_min{-(std::int64_t{1} << 55)};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::Int56>(value_zero);
+  auto result_zero = sdo::deserialize<sdo::Int56>(blob);
+  ASSERT_EQ(result_zero.value, value_zero.value);
+
+  blob = sdo::serialize<sdo::Int56>(value_max);
+  auto result_max = sdo::deserialize<sdo::Int56>(blob);
+  ASSERT_EQ(result_max.value, value_max.value);
+
+  blob = sdo::serialize<sdo::Int56>(value_min);
+  auto result_min = sdo::deserialize<sdo::Int56>(blob);
+  ASSERT_EQ(result_min.value, value_min.value);
+}
+
+TEST(SDOSerializationTest, Int64)
+{
+  std::int64_t value_zero = 0;
+  std::int64_t value_max = std::numeric_limits<std::int64_t>::max();
+  std::int64_t value_min = std::numeric_limits<std::int64_t>::min();
+
+  std::vector<std::uint8_t> blob = sdo::serialize<std::int64_t>(value_zero);
+  auto result_zero = sdo::deserialize<std::int64_t>(blob);
+  ASSERT_EQ(result_zero, value_zero);
+
+  blob = sdo::serialize<std::int64_t>(value_max);
+  auto result_max = sdo::deserialize<std::int64_t>(blob);
+  ASSERT_EQ(result_max, value_max);
+
+  blob = sdo::serialize<std::int64_t>(value_min);
+  auto result_min = sdo::deserialize<std::int64_t>(blob);
+  ASSERT_EQ(result_min, value_min);
+}
+
+TEST(SDOSerializationTest, uInt24)
+{
+  sdo::UInt24 value_zero{0};
+  sdo::UInt24 value_max{(std::uint64_t{1} << 23) - 1};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::UInt24>(value_zero);
+  auto result_zero = sdo::deserialize<sdo::UInt24>(blob);
+  ASSERT_EQ(result_zero.value, value_zero.value);
+
+  blob = sdo::serialize<sdo::UInt24>(value_max);
+  auto result_max = sdo::deserialize<sdo::UInt24>(blob);
+  ASSERT_EQ(result_max.value, value_max.value);
+}
+
+TEST(SDOSerializationTest, uInt40)
+{
+  sdo::UInt40 value_zero{0};
+  sdo::UInt40 value_max{(std::uint64_t{1} << 40) - 1};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::UInt40>(value_zero);
+  auto result_zero = sdo::deserialize<sdo::UInt40>(blob);
+  ASSERT_EQ(result_zero.value, value_zero.value);
+
+  blob = sdo::serialize<sdo::UInt40>(value_max);
+  auto result_max = sdo::deserialize<sdo::UInt40>(blob);
+  ASSERT_EQ(result_max.value, value_max.value);
+}
+
+TEST(SDOSerializationTest, uInt48)
+{
+  sdo::UInt48 value_zero{0};
+  sdo::UInt48 value_max{(std::uint64_t{1} << 48) - 1};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::UInt48>(value_zero);
+  auto result_zero = sdo::deserialize<sdo::UInt48>(blob);
+  ASSERT_EQ(result_zero.value, value_zero.value);
+
+  blob = sdo::serialize<sdo::UInt48>(value_max);
+  auto result_max = sdo::deserialize<sdo::UInt48>(blob);
+  ASSERT_EQ(result_max.value, value_max.value);
+}
+
+TEST(SDOSerializationTest, uInt56)
+{
+  sdo::UInt56 value_zero{0};
+  sdo::UInt56 value_max{(std::uint64_t{1} << 56) - 1};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::UInt56>(value_zero);
+  auto result_zero = sdo::deserialize<sdo::UInt56>(blob);
+  ASSERT_EQ(result_zero.value, value_zero.value);
+
+  blob = sdo::serialize<sdo::UInt56>(value_max);
+  auto result_max = sdo::deserialize<sdo::UInt56>(blob);
+  ASSERT_EQ(result_max.value, value_max.value);
+}
+
+TEST(SDOSerializationTest, uInt64)
+{
+  std::uint64_t value_zero = 0;
+  std::uint64_t value_max = std::numeric_limits<std::uint64_t>::max();
+
+  std::vector<std::uint8_t> blob = sdo::serialize<std::uint64_t>(value_zero);
+  auto result_zero = sdo::deserialize<std::uint64_t>(blob);
+  ASSERT_EQ(result_zero, value_zero);
+
+  blob = sdo::serialize<std::uint64_t>(value_max);
+  auto result_max = sdo::deserialize<std::uint64_t>(blob);
+  ASSERT_EQ(result_max, value_max);
+}
+
+TEST(SDOSerializationTest, Guid)
+{
+  sdo::Guid value{{
+       1,  2,  3,  4,
+       5,  6,  7,  8,
+       9, 10, 11, 12,
+      13, 14, 15, 16
+  }};
+
+  std::vector<std::uint8_t> blob = sdo::serialize<sdo::Guid>(value);
+  auto result = sdo::deserialize<sdo::Guid>(blob);
+  ASSERT_EQ(result.bytes, value.bytes);
 }

--- a/rise_motion_dev_ws/src/rise_motion/test/test_sdo_serializer.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/test/test_sdo_serializer.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+
+#include "rise_motion/sdo_serializer.hpp"
+
+TEST(SDOSerializationTest, Bool)
+{
+  bool value = true;
+
+  std::vector<std::uint8_t> blob = sdo::serialize<bool>(value);
+  auto result = sdo::deserialize<bool>(blob);
+
+  ASSERT_EQ(result, value);
+}
+
+TEST(SDOSerializationTest, Int8)
+{
+  std::int8_t value_zero = 0;
+  std::int8_t value_max = 127;
+  std::int8_t value_min = -128;
+
+  std::vector<std::uint8_t> blob = sdo::serialize<std::int8_t>(value_zero);
+  auto result_zero = sdo::deserialize<std::int8_t>(blob);
+  ASSERT_EQ(result_zero, value_zero);
+
+  blob = sdo::serialize<std::int8_t>(value_max);
+  auto result_max = sdo::deserialize<std::int8_t>(blob);
+  ASSERT_EQ(result_max, value_max);
+
+  blob = sdo::serialize<std::int8_t>(value_min);
+  auto result_min = sdo::deserialize<std::int8_t>(blob);
+  ASSERT_EQ(result_min, value_min);
+}

--- a/rise_motion_dev_ws/src/rise_motion_messages/srv/SDOReadSrv.srv
+++ b/rise_motion_dev_ws/src/rise_motion_messages/srv/SDOReadSrv.srv
@@ -2,6 +2,7 @@ uint16 device_id
 uint16 index
 uint8 subindex
 uint8 value_type
+uint8 value_size
 ---
 int8 status_code
 uint16 device_id


### PR DESCRIPTION
This PR gets the SDO read and write services working in C++. It implements a header-only library for serialization and deserialization of C++ typed values into dynamically sized uint8 arrays and vice versa. In addition, it fixes a few tiny bugs in the underlying SDO read and write services.

Closes issues #57 and #58 