### PR TITLE
Feature #15 Header for Config Values

### DIFF
--- a/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
+++ b/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
@@ -9,7 +9,6 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rise_motion_messages REQUIRED)
-find_package(config QUIET)
 
 include_directories(include)
 
@@ -32,8 +31,10 @@ target_link_libraries(
 	soem
 )
 
-if(config_FOUND)
-  message(NOTE "external config package found: using values from config package")
+if(DEFINED ENV{MOTION_USE_EXTERNAL_CONFIG} AND "$ENV{MOTION_USE_EXTERNAL_CONFIG}" STREQUAL "1")
+  message(NOTE "using values from external config package")
+
+  find_package(config REQUIRED)
 
   target_link_libraries(
     rise_motion_main
@@ -45,7 +46,7 @@ if(config_FOUND)
     PRIVATE EXTERNAL_CONFIG_AVAILABLE=1
   )
 else()
-  message(WARNING "no external config package found: using values from local rise_motion/config.hpp")
+  message(WARNING "no external config package defined: using values from local rise_motion/config.hpp")
 
   target_compile_definitions(
     rise_motion_main

--- a/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
+++ b/rise_motion_dev_ws/src/rise_motion/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rise_motion_messages REQUIRED)
+find_package(config QUIET)
 
 include_directories(include)
 
@@ -30,6 +31,27 @@ target_link_libraries(
 	rise_motion_main
 	soem
 )
+
+if(config_FOUND)
+  message(NOTE "external config package found: using values from config package")
+
+  target_link_libraries(
+    rise_motion_main
+    config::config_settings
+  )
+
+  target_compile_definitions(
+    rise_motion_main
+    PRIVATE EXTERNAL_CONFIG_AVAILABLE=1
+  )
+else()
+  message(WARNING "no external config package found: using values from local rise_motion/config.hpp")
+
+  target_compile_definitions(
+    rise_motion_main
+    PRIVATE EXTERNAL_CONFIG_AVAILABLE=0
+  )
+endif()
 
 #target_link_options(rise_motion_main PRIVATE -Wl,-rpath,/hello/home/rise/Projects/rise-motion/rise_motion_dev_ws/install/rise_motion_messages/lib)
 install(TARGETS

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/config.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/config.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-// if used as part of rise-os-core set the environment variable MOTION_USE EXTERNAL_CONFIG=1 to use the config package
+// if used as part of rise-os-core set the environment variable MOTION_USE_EXTERNAL_CONFIG=1 to use the config package
 
-#if EXTERNAL_CONFIG_AVAILBLE
+#if EXTERNAL_CONFIG_AVAILABLE
 
 #include <config/rise_configurations.hpp>
 

--- a/rise_motion_dev_ws/src/rise_motion/include/rise_motion/config.hpp
+++ b/rise_motion_dev_ws/src/rise_motion/include/rise_motion/config.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+// if used as part of rise-os-core set the environment variable MOTION_USE EXTERNAL_CONFIG=1 to use the config package
+
+#if EXTERNAL_CONFIG_AVAILBLE
+
+#include <config/rise_configurations.hpp>
+
+namespace rise_motion::config
+{
+    inline constexpr int num_motors = static_variables_GroupMotorDefinitions::SIZE;
+}
+
+#else
+
+namespace rise_motion::config
+{
+    inline constexpr int num_motors = 1;
+}
+
+#endif

--- a/rise_motion_dev_ws/src/rise_motion/package.xml
+++ b/rise_motion_dev_ws/src/rise_motion/package.xml
@@ -11,7 +11,7 @@
 
   <depend>rclcpp</depend>
   <depend>rise_motion_messages</depend>
-  <depend condition="MOTION_USE_EXTERNAL_CONFIG == 1">config</depend>
+  <depend condition="$MOTION_USE_EXTERNAL_CONFIG == 1">config</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rise_motion_dev_ws/src/rise_motion/package.xml
+++ b/rise_motion_dev_ws/src/rise_motion/package.xml
@@ -11,6 +11,7 @@
 
   <depend>rclcpp</depend>
   <depend>rise_motion_messages</depend>
+  <depend condition="MOTION_USE_EXTERNAL_CONFIG == 1">config</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rise_motion_dev_ws/src/rise_motion/src/ec_manager.cpp
+++ b/rise_motion_dev_ws/src/rise_motion/src/ec_manager.cpp
@@ -12,11 +12,8 @@
 #include <rise_motion/cia402.hpp>
 #include <rise_motion/ec_manager.hpp>
 #include <soem/soem.h>
+#include <rise_motion/config.hpp>
 
-// expected config, needs to be retrieved from config node
-struct {
-  int slavecount = 1;
-} config;
 
 ECManager::ECManager(const std::string interface, int cycle_time)
     : interface(interface), logger(rclcpp::get_logger("ECManager")),
@@ -51,9 +48,9 @@ int ECManager::init_ec() {
   }
 
   // TODO: More extensive verification of network
-  if (ctx.slavecount != config.slavecount) {
+  if (ctx.slavecount != rise_motion::config::num_motors) {
     RCLCPP_ERROR(logger, "Expected %d devices, but discovered %d",
-                 config.slavecount, ctx.slavecount);
+                 rise_motion::config::num_motors, ctx.slavecount);
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
## Context
See issue #15

## Changes
- adds `config.hpp` for magic numbers and replaces currently hard-coded values for number of motors in the code
- if environment variable `MOTION_USE_EXTERNAL_CONFIG` is set to 1, the config package from `rise-os-core` is added as a dependency of motion and `config.hpp` acts like a wrapper and uses the values from the config package
- if `MOTION_USE_EXTERNAL_CONFIG` is not set, fallback values defined in the local `config.hpp` are used
- related PR https://github.com/riserobotics/rise-os-core/pull/241 in `rise-os-core` sets the variable in the build script

## Result
- depending on the environment variable `MOTION_USE_EXTERNAL_CONFIG`, `rise-motion`  can be either build as a standalone or as part of `rise-os-core` using its config package
- `config.hpp` decouples the code in `rise-motion` from the specifics of the `rise-os-core` config package, enabling easier code reuse